### PR TITLE
Defer db connection test until sqlite db file exists

### DIFF
--- a/lib/gemstash/cli/setup.rb
+++ b/lib/gemstash/cli/setup.rb
@@ -23,8 +23,8 @@ module Gemstash
         ask_database
         ask_strategy
         check_cache
-        check_database
         check_storage
+        check_database
         store_config
         @cli.say @cli.set_color("You are all setup!", :green)
       end


### PR DESCRIPTION
Checking the database configuration fails because it happens before creating a custom storage dir.

#ROSSconf