### PR TITLE
Forward http user agent to the upstream server

### DIFF
--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -114,7 +114,7 @@ module Gemstash
 
       def dependencies
         @dependencies ||= begin
-          http_client = http_client_for(upstream.to_s)
+          http_client = http_client_for(upstream)
           Gemstash::Dependencies.for_upstream(upstream, http_client)
         end
       end
@@ -125,7 +125,7 @@ module Gemstash
       end
 
       def gem_fetcher
-        @gem_fetcher ||= Gemstash::GemFetcher.new(http_client_for(upstream.to_s))
+        @gem_fetcher ||= Gemstash::GemFetcher.new(http_client_for(upstream))
       end
 
       def fetch_gem(id)

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -14,7 +14,12 @@ module Gemstash
         return false unless rewriter.matches?
         rewriter.rewrite
         env["gemstash.upstream"] = rewriter.captures["upstream_url"]
+        capture_user_agent(env)
         true
+      end
+
+      def self.capture_user_agent(env)
+        env["gemstash.user-agent"] = env["HTTP_USER_AGENT"]
       end
 
       def serve_root
@@ -89,7 +94,8 @@ module Gemstash
     private
 
       def upstream
-        @upstream ||= Gemstash::Upstream.new(env["gemstash.upstream"])
+        @upstream ||= Gemstash::Upstream.new(env["gemstash.upstream"],
+          user_agent: env["gemstash.user-agent"])
       end
     end
 
@@ -160,6 +166,7 @@ module Gemstash
         else
           env["gemstash.upstream"] = env["HTTP_X_GEMFILE_SOURCE"]
         end
+        capture_user_agent(env)
 
         true
       end

--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -15,22 +15,27 @@ module Gemstash
 
   #:nodoc:
   class HTTPClient
+    DEFAULT_USER_AGENT = "Gemstash #{Gemstash::VERSION}"
+
     def self.for(upstream)
       client = Faraday.new(upstream.url) do |config|
         config.use FaradayMiddleware::FollowRedirects
         config.adapter :net_http
       end
+      user_agent = DEFAULT_USER_AGENT
+      user_agent << " - #{upstream.user_agent}" unless upstream.user_agent.to_s.empty?
 
-      new(client)
+      new(client, user_agent: user_agent)
     end
 
-    def initialize(client = nil)
+    def initialize(client = nil, user_agent: nil)
       @client = client
+      @user_agent = user_agent || DEFAULT_USER_AGENT
     end
 
     def get(path)
       response = @client.get(path) do |req|
-        req.headers["User-Agent"] = "Gemstash #{Gemstash::VERSION}"
+        req.headers["User-Agent"] = @user_agent
         req.options.open_timeout = 2
       end
 

--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -15,15 +15,15 @@ module Gemstash
 
   #:nodoc:
   class HTTPClient
-    DEFAULT_USER_AGENT = "Gemstash #{Gemstash::VERSION}"
+    DEFAULT_USER_AGENT = "Gemstash/#{Gemstash::VERSION}"
 
     def self.for(upstream)
       client = Faraday.new(upstream.to_s) do |config|
         config.use FaradayMiddleware::FollowRedirects
         config.adapter :net_http
       end
-      user_agent = DEFAULT_USER_AGENT
-      user_agent << " - #{upstream.user_agent}" unless upstream.user_agent.to_s.empty?
+      user_agent = "#{upstream.user_agent} " unless upstream.user_agent.to_s.empty?
+      user_agent = user_agent.to_s + DEFAULT_USER_AGENT
 
       new(client, user_agent: user_agent)
     end

--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -18,7 +18,7 @@ module Gemstash
     DEFAULT_USER_AGENT = "Gemstash #{Gemstash::VERSION}"
 
     def self.for(upstream)
-      client = Faraday.new(upstream.url) do |config|
+      client = Faraday.new(upstream.to_s) do |config|
         config.use FaradayMiddleware::FollowRedirects
         config.adapter :net_http
       end

--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -15,8 +15,8 @@ module Gemstash
 
   #:nodoc:
   class HTTPClient
-    def self.for(server_url)
-      client = Faraday.new(server_url) do |config|
+    def self.for(upstream)
+      client = Faraday.new(upstream.url) do |config|
         config.use FaradayMiddleware::FollowRedirects
         config.adapter :net_http
       end

--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -30,6 +30,7 @@ module Gemstash
 
     def get(path)
       response = @client.get(path) do |req|
+        req.headers["User-Agent"] = "Gemstash"
         req.options.open_timeout = 2
       end
 

--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -30,7 +30,7 @@ module Gemstash
 
     def get(path)
       response = @client.get(path) do |req|
-        req.headers["User-Agent"] = "Gemstash"
+        req.headers["User-Agent"] = "Gemstash #{Gemstash::VERSION}"
         req.options.open_timeout = 2
       end
 

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -5,10 +5,13 @@ module Gemstash
   class Upstream
     extend Forwardable
 
+    attr_accessor :user_agent
+
     def_delegators :@uri, :scheme, :host, :user, :password, :to_s
 
-    def initialize(upstream)
+    def initialize(upstream, user_agent: nil)
       @uri = URI(URI.decode(upstream.to_s))
+      @user_agent = user_agent
       raise "URL '#{@uri}' is not valid!" unless @uri.to_s =~ URI.regexp
     end
 

--- a/spec/gemstash/http_client_spec.rb
+++ b/spec/gemstash/http_client_spec.rb
@@ -85,7 +85,7 @@ describe Gemstash::HTTPClient do
         let(:http_client) { Gemstash::HTTPClient.new(faraday_client) }
 
         it "forwards the default user agent to the remote server" do
-          stubs.get("/gems/rack", "User-Agent" => "Gemstash #{Gemstash::VERSION}") do
+          stubs.get("/gems/rack", "User-Agent" => "Gemstash/#{Gemstash::VERSION}") do
             [200, { "CONTENT-TYPE" => "octet/stream" }, "zapatito"]
           end
           http_client.get("/gems/rack")

--- a/spec/gemstash/http_client_spec.rb
+++ b/spec/gemstash/http_client_spec.rb
@@ -62,27 +62,52 @@ describe Gemstash::HTTPClient do
       end
     end
 
-    context "with a block to store the headers" do
-      let(:faraday_client) do
-        stubs = Faraday::Adapter::Test::Stubs.new do |stub|
-          stub.get("/gems/rack") { [200, { "CONTENT-TYPE" => "octet/stream" }, "zapatito"] }
+    context "with a stubbed faraday client" do
+      let(:stubs) { Faraday::Adapter::Test::Stubs.new }
+      let(:faraday_client) { Faraday.new {|builder| builder.adapter(:test, stubs) } }
+
+      context "with a client that specifies a user agent" do
+        let(:http_client) do
+          Gemstash::HTTPClient.new(faraday_client,
+            user_agent: "my-agent 6.6.6")
         end
-        Faraday.new {|builder| builder.adapter(:test, stubs) }
+
+        it "forwards the user agent to the remote server" do
+          stubs.get("/gems/rack", "User-Agent" => "my-agent 6.6.6") do
+            [200, { "CONTENT-TYPE" => "octet/stream" }, "zapatito"]
+          end
+          http_client.get("/gems/rack")
+          stubs.verify_stubbed_calls
+        end
       end
 
-      let(:http_client) { Gemstash::HTTPClient.new(faraday_client) }
+      context "with a simple client" do
+        let(:http_client) { Gemstash::HTTPClient.new(faraday_client) }
 
-      it "throws an error" do
-        body_result = nil
-        headers_result = nil
-
-        http_client.get("/gems/rack") do |body, headers|
-          body_result = body
-          headers_result = headers
+        it "forwards the default user agent to the remote server" do
+          stubs.get("/gems/rack", "User-Agent" => "Gemstash #{Gemstash::VERSION}") do
+            [200, { "CONTENT-TYPE" => "octet/stream" }, "zapatito"]
+          end
+          http_client.get("/gems/rack")
+          stubs.verify_stubbed_calls
         end
 
-        expect(body_result).to eq("zapatito")
-        expect(headers_result).to eq("CONTENT-TYPE" => "octet/stream")
+        context "with a block to store the headers" do
+          it "throws an error" do
+            stubs.get("/gems/rack") { [200, { "CONTENT-TYPE" => "octet/stream" }, "zapatito"] }
+
+            body_result = nil
+            headers_result = nil
+
+            http_client.get("/gems/rack") do |body, headers|
+              body_result = body
+              headers_result = headers
+            end
+
+            expect(body_result).to eq("zapatito")
+            expect(headers_result).to eq("CONTENT-TYPE" => "octet/stream")
+          end
+        end
       end
     end
   end

--- a/spec/gemstash/http_client_spec.rb
+++ b/spec/gemstash/http_client_spec.rb
@@ -21,7 +21,7 @@ describe Gemstash::HTTPClient do
 
   describe ".get" do
     let(:http_client) do
-      Gemstash::HTTPClient.for(@server.url)
+      Gemstash::HTTPClient.for(Gemstash::Upstream.new(@server.url))
     end
 
     context "with a valid url" do

--- a/spec/gemstash/upstream_spec.rb
+++ b/spec/gemstash/upstream_spec.rb
@@ -50,6 +50,15 @@ describe Gemstash::Upstream do
       /URL 'something_that_is_not_an_uri' is not valid/)
   end
 
+  it "has a nil user agent if not provided" do
+    expect(Gemstash::Upstream.new("https://rubygems.org/").user_agent).to be_nil
+  end
+
+  it "supports getting user agent" do
+    expect(Gemstash::Upstream.new("https://rubygems.org/",
+      user_agent: "my_user_agent").user_agent).to eq("my_user_agent")
+  end
+
   describe ".url" do
     let(:server_url) { "https://www.rubygems.org" }
     let(:upstream) { Gemstash::Upstream.new(server_url) }


### PR DESCRIPTION
This change is about sending the client user agent plus a "Gemstash VERSION - " to the upstream server.

This is useful to track the use of gemstash as a client, while keeping the original bundler user agent in the request.

cc @indirect @smellsblue 