### PR TITLE
Handle upstream connection error correctly and die with dignity

### DIFF
--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -114,8 +114,6 @@ module Gemstash
         gem.content
       rescue Gemstash::WebError => e
         halt e.code
-      rescue Gemstash::ConnectionError
-        halt 502 # Bad Gateway
       end
 
     private

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -114,6 +114,8 @@ module Gemstash
         gem.content
       rescue Gemstash::WebError => e
         halt e.code
+      rescue Gemstash::ConnectionError
+        halt 502 # Bad Gateway
       end
 
     private

--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -14,7 +14,10 @@ module Gemstash
   end
 
   #:nodoc:
-  class ConnectionError < StandardError
+  class ConnectionError < WebError
+    def initialize(message)
+      super(message, 502) # Bad Gateway
+    end
   end
 
   #:nodoc:

--- a/spec/gemstash/http_client_spec.rb
+++ b/spec/gemstash/http_client_spec.rb
@@ -99,6 +99,8 @@ describe Gemstash::HTTPClient do
           end
           expect { http_client.get("/gems/rack") }.to raise_error do |error|
             expect(error).to be_a(Gemstash::ConnectionError)
+            expect(error.message).to eq("I don't like your DNS query!")
+            expect(error.code).to eq(502)
           end
         end
 


### PR DESCRIPTION
Solving #27.

I'm just considering the case of a possible ConnectionFailed (DNS failure in my case), and in such case, retry 3 times, and then die with an error that can be interpreted by the browser rather than an error 500.