### PR TITLE
Older RubyGems and Ruby 2.0.0

### DIFF
--- a/lib/gemstash/gem_pusher.rb
+++ b/lib/gemstash/gem_pusher.rb
@@ -1,7 +1,7 @@
 require "rubygems/package"
 require "stringio"
-require "tempfile"
 
+#:nodoc:
 module Gemstash
   # Class that supports pushing a new gem to the private repository of gems.
   class GemPusher
@@ -26,29 +26,12 @@ module Gemstash
       store_gem
       save_to_database
       invalidate_cache
-    ensure
-      cleanup
     end
 
   private
 
-    def cleanup
-      return unless @tempfile
-      @tempfile.close
-      @tempfile.unlink
-    end
-
     def gem
-      @gem ||= begin
-        if Gem::Requirement.new("~> 2.4").satisfied_by?(Gem::Version.new(Gem::VERSION))
-          Gem::Package.new(StringIO.new(@content))
-        else
-          @tempfile = Tempfile.new("gemstash-gem")
-          @tempfile.write(@content)
-          @tempfile.flush
-          Gem::Package.new(@tempfile.path)
-        end
-      end
+      @gem ||= Gem::Package.new(StringIO.new(@content))
     end
 
     def storage
@@ -89,5 +72,45 @@ module Gemstash
     def invalidate_cache
       gemstash_env.cache.invalidate_gem("private", gem.spec.name)
     end
+  end
+
+  unless Gem::Requirement.new("~> 2.4").satisfied_by?(Gem::Version.new(Gem::VERSION))
+    require "tempfile"
+
+    # Adds support for legacy versions of RubyGems
+    module LegacyRubyGemsSupport
+      def self.included(base)
+        base.class_eval do
+          alias_method :push_without_cleanup, :push
+          remove_method :push
+          remove_method :gem
+        end
+      end
+
+      def push
+        push_without_cleanup
+      ensure
+        cleanup
+      end
+
+    private
+
+      def gem
+        @gem ||= begin
+          @tempfile = Tempfile.new("gemstash-gem")
+          @tempfile.write(@content)
+          @tempfile.flush
+          Gem::Package.new(@tempfile.path)
+        end
+      end
+
+      def cleanup
+        return unless @tempfile
+        @tempfile.close
+        @tempfile.unlink
+      end
+    end
+
+    GemPusher.send(:include, LegacyRubyGemsSupport)
   end
 end

--- a/lib/gemstash/gem_pusher.rb
+++ b/lib/gemstash/gem_pusher.rb
@@ -74,7 +74,7 @@ module Gemstash
     end
   end
 
-  unless Gem::Requirement.new("~> 2.4").satisfied_by?(Gem::Version.new(Gem::VERSION))
+  unless Gem::Requirement.new(">= 2.4").satisfied_by?(Gem::Version.new(Gem::VERSION))
     require "tempfile"
 
     # Adds support for legacy versions of RubyGems

--- a/spec/data/environments/integration_spec/push_gem/.gem/credentials
+++ b/spec/data/environments/integration_spec/push_gem/.gem/credentials
@@ -1,2 +1,3 @@
 ---
+:rubygems_api_key: fake-key
 :test: test-key

--- a/spec/support/test_gemstash_server.rb
+++ b/spec/support/test_gemstash_server.rb
@@ -4,7 +4,9 @@ require "support/server_check"
 
 # Launches a test Gemstash server directly via Puma.
 class TestGemstashServer
-  def initialize(port:, config:)
+  def initialize(port: nil, config: nil)
+    raise "Port is required" unless port
+    raise "Config is required" unless config
     @port = port
     args = %w(--config -)
     args += %w(--workers 0)


### PR DESCRIPTION
It started as an experiment based on @pcarranza's findings and #32, but I wanted to see if older RubyGems support and Ruby 2.0.0 support was reasonable to do. If we accept this, I think we should update #31 to include Ruby 2.0.0.