### PR TITLE
Various fixes

### DIFF
--- a/lib/gemstash/dependencies.rb
+++ b/lib/gemstash/dependencies.rb
@@ -74,7 +74,7 @@ module Gemstash
         return unless @http_client
         log.info "Fetching dependencies: #{@gems.to_a.join(", ")}"
         gems_param = @gems.map {|gem| CGI.escape(gem) }.join(",")
-        fetched = @http_client.get("/api/v1/dependencies?gems=#{gems_param}")
+        fetched = @http_client.get("api/v1/dependencies?gems=#{gems_param}")
         fetched = Marshal.load(fetched).group_by {|r| r[:name] }
 
         fetched.each do |gem, result|

--- a/lib/gemstash/gem_fetcher.rb
+++ b/lib/gemstash/gem_fetcher.rb
@@ -10,7 +10,7 @@ module Gemstash
     end
 
     def fetch(gem_id, &block)
-      @http_client.get("/gems/#{gem_id}") do |body, headers|
+      @http_client.get("gems/#{gem_id}") do |body, headers|
         properties = filter_headers(headers)
         validate_download(body, properties)
         yield body, properties

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -48,47 +48,47 @@ module Gemstash
       end
 
       def serve_dependencies
-        redirect upstream.url("/api/v1/dependencies", request.query_string)
+        redirect upstream.url("api/v1/dependencies", request.query_string)
       end
 
       def serve_dependencies_json
-        redirect upstream.url("/api/v1/dependencies.json", request.query_string)
+        redirect upstream.url("api/v1/dependencies.json", request.query_string)
       end
 
       def serve_names
-        redirect upstream.url("/names", request.query_string)
+        redirect upstream.url("names", request.query_string)
       end
 
       def serve_versions
-        redirect upstream.url("/versions", request.query_string)
+        redirect upstream.url("versions", request.query_string)
       end
 
       def serve_info(name)
-        redirect upstream.url("/info/#{name}", request.query_string)
+        redirect upstream.url("info/#{name}", request.query_string)
       end
 
       def serve_marshal(id)
-        redirect upstream.url("/quick/Marshal.4.8/#{id}", request.query_string)
+        redirect upstream.url("quick/Marshal.4.8/#{id}", request.query_string)
       end
 
       def serve_actual_gem(id)
-        redirect upstream.url("/fetch/actual/gem/#{id}", request.query_string)
+        redirect upstream.url("fetch/actual/gem/#{id}", request.query_string)
       end
 
       def serve_gem(id)
-        redirect upstream.url("/gems/#{id}", request.query_string)
+        redirect upstream.url("gems/#{id}", request.query_string)
       end
 
       def serve_latest_specs
-        redirect upstream.url("/latest_specs.4.8.gz", request.query_string)
+        redirect upstream.url("latest_specs.4.8.gz", request.query_string)
       end
 
       def serve_specs
-        redirect upstream.url("/specs.4.8.gz", request.query_string)
+        redirect upstream.url("specs.4.8.gz", request.query_string)
       end
 
       def serve_prerelease_specs
-        redirect upstream.url("/prerelease_specs.4.8.gz", request.query_string)
+        redirect upstream.url("prerelease_specs.4.8.gz", request.query_string)
       end
 
     private

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -110,7 +110,7 @@ module Gemstash
 
       def serve_gem(id)
         gem = fetch_gem(id)
-        headers.update(gem.properties)
+        headers.update(gem.properties[:headers] || {})
         gem.content
       rescue Gemstash::WebError => e
         halt e.code
@@ -152,7 +152,7 @@ module Gemstash
       def fetch_remote_gem(gem_name, gem_resource)
         log.info "Gem #{gem_name.name} is not cached, fetching"
         gem_fetcher.fetch(gem_name.id) do |content, properties|
-          gem_resource.save(content, properties: properties)
+          gem_resource.save(content, headers: properties)
         end
       end
     end

--- a/lib/gemstash/storage.rb
+++ b/lib/gemstash/storage.rb
@@ -57,7 +57,7 @@ module Gemstash
       File.exist?(content_filename) && File.exist?(properties_filename)
     end
 
-    def save(content, properties: nil)
+    def save(content, properties = nil)
       @content = content
       @properties = properties
       store
@@ -89,11 +89,11 @@ module Gemstash
 
     def save_file(filename)
       content = yield
-      File.open(filename, "w") {|f| f.write(content) }
+      File.open(filename, "wb") {|f| f.write(content) }
     end
 
     def read_file(filename)
-      File.open(filename, &:read)
+      File.open(filename, "rb", &:read)
     end
 
     def content_filename

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -16,8 +16,15 @@ module Gemstash
     end
 
     def url(path = nil, params = nil)
+      base = to_s
+
+      unless path.to_s.empty?
+        base = "#{base}/" unless base.end_with?("/")
+        path = path[1..-1] if path.to_s.start_with?("/")
+      end
+
       params = "?#{params}" if !params.nil? && !params.empty?
-      "#{self}#{path}#{params}"
+      "#{base}#{path}#{params}"
     end
 
     def auth?

--- a/spec/gemstash/dependencies_spec.rb
+++ b/spec/gemstash/dependencies_spec.rb
@@ -7,8 +7,8 @@ describe Gemstash::Dependencies do
   let(:db_deps) { Gemstash::Dependencies.for_private }
 
   def valid_url(url, expected_gems)
-    expect(url).to start_with("/api/v1/dependencies?gems=")
-    params = url.sub("/api/v1/dependencies?gems=", "")
+    expect(url).to start_with("api/v1/dependencies?gems=")
+    params = url.sub("api/v1/dependencies?gems=", "")
     expect(params.split(",")).to match_array(expected_gems)
   end
 

--- a/spec/gemstash/gem_pusher_spec.rb
+++ b/spec/gemstash/gem_pusher_spec.rb
@@ -13,7 +13,7 @@ describe Gemstash::GemPusher do
 
   describe ".push" do
     let(:deps) { Gemstash::Dependencies.for_private }
-    let(:gem_contents) { File.read(gem_path("example", "0.1.0")) }
+    let(:gem_contents) { File.open(gem_path("example", "0.1.0"), "rb", &:read) }
 
     context "without authorization" do
       it "prevents pushing" do

--- a/spec/gemstash/storage_spec.rb
+++ b/spec/gemstash/storage_spec.rb
@@ -54,9 +54,15 @@ describe Gemstash::Storage do
       end
 
       it "can also save properties" do
-        resource.save("some other content", properties: { "content-type" => "octet/stream" })
+        resource.save("some other content", "content-type" => "octet/stream")
         expect(resource.content).to eq("some other content")
         expect(resource.properties).to eq("content-type" => "octet/stream")
+      end
+
+      it "can save nested properties" do
+        resource.save("some other content", headers: { "content-type" => "octet/stream" })
+        expect(resource.content).to eq("some other content")
+        expect(resource.properties).to eq(headers: { "content-type" => "octet/stream" })
       end
     end
 

--- a/spec/gemstash/upstream_spec.rb
+++ b/spec/gemstash/upstream_spec.rb
@@ -79,13 +79,13 @@ describe Gemstash::Upstream do
 
     context "with just a path provided" do
       it "returns the url" do
-        expect(upstream.url("/path/somewhere")).to eq("https://www.rubygems.org/path/somewhere")
+        expect(upstream.url("path/somewhere")).to eq("https://www.rubygems.org/path/somewhere")
       end
     end
 
     context "with just a path and query string provided" do
       it "returns the url" do
-        expect(upstream.url("/path/somewhere", "abc=123")).to eq("https://www.rubygems.org/path/somewhere?abc=123")
+        expect(upstream.url("path/somewhere", "abc=123")).to eq("https://www.rubygems.org/path/somewhere?abc=123")
       end
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -43,7 +43,7 @@ describe "gemstash integration tests" do
       let(:storage) { Gemstash::Storage.for("private").for("gems") }
       let(:deps) { Gemstash::Dependencies.for_private }
       let(:gem) { gem_path("speaker", "0.1.0") }
-      let(:gem_contents) { File.read(gem) }
+      let(:gem_contents) { File.open(gem, "rb", &:read) }
       let(:env_dir) { env_path("integration_spec/push_gem") }
 
       let(:speaker_deps) do
@@ -130,7 +130,7 @@ describe "gemstash integration tests" do
     context "with private gems", :db_transaction => false do
       before do
         Gemstash::Authorization.authorize("test-key", "all")
-        gem_contents = File.read(gem_path("speaker", "0.1.0"))
+        gem_contents = File.open(gem_path("speaker", "0.1.0"), "rb", &:read)
         Gemstash::GemPusher.new("test-key", gem_contents).push
       end
 

--- a/spec/support/simple_server.rb
+++ b/spec/support/simple_server.rb
@@ -81,7 +81,7 @@ class SimpleServer
     mount("/gems/#{name}-#{version}.gem") do |_, response|
       response.status = 200
       response.content_type = "application/octet-stream"
-      response.body = File.read(gem_path(name, version))
+      response.body = File.open(gem_path(name, version), "rb", &:read)
     end
   end
 


### PR DESCRIPTION
Faraday treats leading `/` as an absolute path, blowing away any path in the originally provided uri. I updated `Gemstash::Upstream` and `Gemstash::HTTPClient` to behave the same way, otherwise there will be bugs if you try to have an upstream that goes to something with a path.

Move headers to a nested key in the properties file of storage, leaving open the possibility to store other metadata without clashing with the headers.

Read/write content as binary, otherwise some specs can fail with differing gem contents or encoding errors.