### PR TITLE
Support mysql as DB backend

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -182,6 +182,7 @@ Specify the API key to affect. This should be the actual key value, not a name.
 This option is required when using `--remove` but is optional otherwise. If
 adding an authorization, using this will either create or update the permissions
 for the specified API key. If missing, a new API key will always be generated.
+Note that a key can only have a maximum length of 255 chars.
 
 #### --remove
 

--- a/lib/gemstash/cli/setup.rb
+++ b/lib/gemstash/cli/setup.rb
@@ -77,27 +77,27 @@ module Gemstash
 
       def ask_database
         say_current_config(:db_adapter, "Current database adapter")
-        options = %w(sqlite3 postgres)
+        options = %w(sqlite3 postgres mysql)
         database = nil
 
         until database
-          database = @cli.ask "What database adapter? [SQLITE3, postgres]"
+          database = @cli.ask "What database adapter? [SQLITE3, postgres, mysql]"
           database = database.downcase
           database = "sqlite3" if database.empty?
           database = nil unless options.include?(database)
         end
 
         @config[:db_adapter] = database
-        ask_postgres_details if database == "postgres"
+        ask_database_details(database) unless database == "sqlite3"
       end
 
-      def ask_postgres_details
+      def ask_database_details(database = "postgres")
         say_current_config(:db_url, "Current database url")
 
         if RUBY_PLATFORM == "java"
-          default_value = "jdbc:postgres:///gemstash"
+          default_value = "jdbc:#{database}:///gemstash"
         else
-          default_value = "postgres:///gemstash"
+          default_value = "#{database}:///gemstash"
         end
 
         url = @cli.ask "Where is the database? [#{default_value}]"

--- a/lib/gemstash/cli/setup.rb
+++ b/lib/gemstash/cli/setup.rb
@@ -91,7 +91,7 @@ module Gemstash
         ask_database_details(database) unless database == "sqlite3"
       end
 
-      def ask_database_details(database = "postgres")
+      def ask_database_details(database)
         say_current_config(:db_url, "Current database url")
 
         if RUBY_PLATFORM == "java"

--- a/lib/gemstash/env.rb
+++ b/lib/gemstash/env.rb
@@ -113,7 +113,7 @@ module Gemstash
           else
             db = Sequel.connect("sqlite://#{URI.escape(db_path)}", max_connections: 1)
           end
-        when "postgres"
+        when "postgres", "mysql"
           db = Sequel.connect(config[:db_url])
         else
           raise "Unsupported DB adapter: '#{config[:db_adapter]}'"

--- a/lib/gemstash/migrations/02_authorizations.rb
+++ b/lib/gemstash/migrations/02_authorizations.rb
@@ -2,7 +2,7 @@ Sequel.migration do
   change do
     create_table :authorizations do
       primary_key :id
-      String :auth_key, :size => 2056, :null => false
+      String :auth_key, :size => 255, :null => false
       String :permissions, :size => 255, :null => false
       DateTime :created_at, :null => false
       DateTime :updated_at, :null => false

--- a/lib/gemstash/version.rb
+++ b/lib/gemstash/version.rb
@@ -1,4 +1,4 @@
 #:nodoc:
 module Gemstash
-  VERSION = "1.0.0.pre.1"
+  VERSION = "1.0.0.pre.2"
 end


### PR DESCRIPTION
This provides mysql as DB backend, and also reduces the size of the authorization key because mysql does not support keys so large (and they are not necessary)

Fixes #51 

cc @indirect @smellsblue 