### PR TITLE
Add --pre option to gemstash installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ against a Gemstash server running on your machine.
 Install Gemstash to get started:
 
 ```
-$ gem install gemstash
+$ gem install gemstash --pre
 ```
 
 After it is installed, starting Gemstash requires no additional steps. Simply


### PR DESCRIPTION
Add pre option to gem install command since ```gem install gemstash``` throws ```ERROR:  Could not find a valid gem 'gemstash' (>= 0) in any repository```