### PR TITLE
Fail on missing specified config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
 - 2.2
 - ruby-head
 bundler_args: "--binstubs --jobs=3 --retry=3"
-before_install: gem install bundler -v 1.10.6
+before_install: gem install bundler -v 1.11.2
 cache: bundler
 script:
 - bundle exec rake spec

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -39,7 +39,7 @@ you push your own private gems as well."
     spec.add_runtime_dependency "sqlite3", "~> 1.3"
   end
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "citrus", "~> 3.0"
   spec.add_development_dependency "octokit", "~> 4.2"
   spec.add_development_dependency "rack-test", "~> 0.6"

--- a/lib/gemstash/cli/base.rb
+++ b/lib/gemstash/cli/base.rb
@@ -30,6 +30,8 @@ module Gemstash
       def store_config
         config = Gemstash::Configuration.new(file: @cli.options[:config_file])
         gemstash_env.config = config
+      rescue Gemstash::Configuration::MissingFileError => e
+        raise Gemstash::CLI::Error.new(@cli, e.message)
       end
 
       def check_gemstash_version

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -13,12 +13,21 @@ module Gemstash
 
     DEFAULT_FILE = File.expand_path("~/.gemstash/config.yml").freeze
 
+    # This error is thrown when a config file is explicitly specified that
+    # doesn't exist.
+    class MissingFileError < StandardError
+      def initialize(file)
+        super("Missing config file: #{file}")
+      end
+    end
+
     def initialize(file: nil, config: nil)
       if config
         @config = DEFAULTS.merge(config).freeze
         return
       end
 
+      raise MissingFileError, file if file && !File.exist?(file)
       file ||= DEFAULT_FILE
 
       if File.exist?(file)

--- a/spec/gemstash/cli/base_spec.rb
+++ b/spec/gemstash/cli/base_spec.rb
@@ -57,4 +57,18 @@ describe Gemstash::CLI::Base do
       expect { base.send(:check_gemstash_version) }.to raise_error(Gemstash::CLI::Error, /does not support version/)
     end
   end
+
+  describe "#store_config" do
+    let(:base) { Gemstash::CLI::Base.new(cli) }
+
+    it "fails if the config file doesn't exist" do
+      allow(cli).to receive(:options).and_return(config_file: File.join(TEST_BASE_PATH, "missing_file.yml"))
+      expect { base.send(:store_config) }.to raise_error(Gemstash::CLI::Error, /missing_file\.yml/)
+    end
+
+    it "fails if the config file is specified as empty" do
+      allow(cli).to receive(:options).and_return(config_file: "")
+      expect { base.send(:store_config) }.to raise_error(Gemstash::CLI::Error, /Missing config file/)
+    end
+  end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -195,7 +195,7 @@ describe "gemstash integration tests" do
     end
 
     # This should stay skipped until bundler sends the X-Gemfile-Source header
-    xcontext "with upstream gems via a header mirror" do
+    context "with upstream gems via a header mirror" do
       let(:bundle) { "integration_spec/header_mirror_gems" }
       it_behaves_like "a bundleable project"
     end


### PR DESCRIPTION
If a config is specified, fail explicitly if the file is missing. The current behavior is to silently use default settings.

This also enables some specs that were pending Bundler 1.11.