### PR TITLE
Index cached gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.0.0.pre.4 (2015-12-23)
+
+### Upgrade Notes
+
+  Any gems fetched before this release won't be indexed, which means plugins you
+  might install can't know about them. These cached gems might also have
+  incorrect headers stored (which shouldn't affect bundling). If you wish to
+  correct this, you can delete or back up your cache by deleting or moving your
+  `~/.gemstash/gem_cache` directory.
+
+### Bugfixes
+
+  - Cached gem and spec headers don't clobber each other ([#68](https://github.com/bundler/gemstash/pull/68), [@smellsblue](https://github.com/smellsblue))
+
+### Features
+
+  - Index cached gems and their upstreams for future use of plugins ([#68](https://github.com/bundler/gemstash/pull/68), [@smellsblue](https://github.com/smellsblue))
+
 ## 1.0.0.pre.3 (2015-12-21)
 
 ### Bugfixes

--- a/lib/gemstash/db.rb
+++ b/lib/gemstash/db.rb
@@ -8,8 +8,10 @@ module Gemstash
     Sequel::Model.raise_on_save_failure = true
     Sequel::Model.plugin :timestamps, update_on_create: true
     autoload :Authorization, "gemstash/db/authorization"
+    autoload :CachedRubygem, "gemstash/db/cached_rubygem"
     autoload :Dependency,    "gemstash/db/dependency"
     autoload :Rubygem,       "gemstash/db/rubygem"
+    autoload :Upstream,      "gemstash/db/upstream"
     autoload :Version,       "gemstash/db/version"
   end
 end

--- a/lib/gemstash/db/cached_rubygem.rb
+++ b/lib/gemstash/db/cached_rubygem.rb
@@ -1,0 +1,17 @@
+require "gemstash"
+
+module Gemstash
+  module DB
+    # Sequel model for cached_rubygems table.
+    class CachedRubygem < Sequel::Model
+      def self.store(upstream, gem_name, resource_type)
+        db.transaction do
+          upstream_id = Gemstash::DB::Upstream.find_or_insert(upstream)
+          record = self[upstream_id: upstream_id, name: gem_name.name, resource_type: resource_type.to_s]
+          return record.id if record
+          new(upstream_id: upstream_id, name: gem_name.name, resource_type: resource_type.to_s).tap(&:save).id
+        end
+      end
+    end
+  end
+end

--- a/lib/gemstash/db/upstream.rb
+++ b/lib/gemstash/db/upstream.rb
@@ -1,0 +1,12 @@
+module Gemstash
+  module DB
+    # Sequel model for upstreams table.
+    class Upstream < Sequel::Model
+      def self.find_or_insert(upstream)
+        record = self[uri: upstream.to_s]
+        return record.id if record
+        new(uri: upstream.to_s, host_id: upstream.host_id).tap(&:save).id
+      end
+    end
+  end
+end

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -160,7 +160,13 @@ module Gemstash
       def fetch_remote_gem(gem_name, gem_resource, resource_type)
         log.info "Gem #{gem_name.name} is not cached, fetching #{resource_type}"
         gem_fetcher.fetch(gem_name.id, resource_type) do |content, properties|
-          gem = gem_resource.save({ resource_type => content }, headers: { resource_type => properties })
+          resource_properties = {
+            upstream: upstream.to_s,
+            gem_name: gem_name.name,
+            headers: { resource_type => properties }
+          }
+
+          gem = gem_resource.save({ resource_type => content }, resource_properties)
           Gemstash::DB::CachedRubygem.store(upstream, gem_name, resource_type)
           gem
         end

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -160,7 +160,9 @@ module Gemstash
       def fetch_remote_gem(gem_name, gem_resource, resource_type)
         log.info "Gem #{gem_name.name} is not cached, fetching #{resource_type}"
         gem_fetcher.fetch(gem_name.id, resource_type) do |content, properties|
-          gem_resource.save({ resource_type => content }, headers: { resource_type => properties })
+          gem = gem_resource.save({ resource_type => content }, headers: { resource_type => properties })
+          Gemstash::DB::CachedRubygem.store(upstream, gem_name, resource_type)
+          gem
         end
       end
     end

--- a/lib/gemstash/migrations/03_cached_gems.rb
+++ b/lib/gemstash/migrations/03_cached_gems.rb
@@ -17,7 +17,7 @@ Sequel.migration do
       String :resource_type, size: 191, null: false
       DateTime :created_at, null: false
       DateTime :updated_at, null: false
-      index [:upstream_id, :name, :resource_type], unique: true
+      index [:upstream_id, :resource_type, :name], unique: true
       index [:name]
     end
   end

--- a/lib/gemstash/migrations/03_cached_gems.rb
+++ b/lib/gemstash/migrations/03_cached_gems.rb
@@ -1,0 +1,24 @@
+Sequel.migration do
+  change do
+    create_table :upstreams do
+      primary_key :id
+      String :uri, size: 191, null: false
+      String :host_id, size: 191, null: false
+      DateTime :created_at, null: false
+      DateTime :updated_at, null: false
+      index [:uri], unique: true
+      index [:host_id], unique: true
+    end
+
+    create_table :cached_rubygems do
+      primary_key :id
+      Integer :upstream_id, null: false
+      String :name, size: 191, null: false
+      String :resource_type, size: 191, null: false
+      DateTime :created_at, null: false
+      DateTime :updated_at, null: false
+      index [:upstream_id, :name, :resource_type], unique: true
+      index [:name]
+    end
+  end
+end

--- a/lib/gemstash/version.rb
+++ b/lib/gemstash/version.rb
@@ -1,4 +1,4 @@
 #:nodoc:
 module Gemstash
-  VERSION = "1.0.0.pre.3"
+  VERSION = "1.0.0.pre.4"
 end

--- a/rake/changelog.citrus
+++ b/rake/changelog.citrus
@@ -83,7 +83,7 @@ grammar Changelog::Grammar
   end
 
   rule paragraph
-    ("  " !"- " /\w[^\n]*/ "\n")+ "\n"
+    ("  " !"- " /(\w|`)[^\n]*/ "\n")+ "\n"
   end
 
   rule changes

--- a/spec/gemstash/storage_spec.rb
+++ b/spec/gemstash/storage_spec.rb
@@ -119,6 +119,17 @@ describe Gemstash::Storage do
           to eq(key: "new", other: :value, new: 42, gemstash_resource_version: Gemstash::Resource::VERSION)
       end
 
+      it "can merge nested properties" do
+        resource = storage.resource(resource_id)
+        resource.save({ gem: "some gem content" }, headers: { gem: { foo: "bar" } })
+        resource.save({ spec: "some spec content" }, headers: { spec: { foo: "baz" } })
+        expect(resource.properties).to eq(headers: { gem: { foo: "bar" }, spec: { foo: "baz" } },
+                                          gemstash_resource_version: Gemstash::Resource::VERSION)
+        resource.save({ spec: "some spec content" }, headers: { spec: { foo: "changed" } })
+        expect(resource.properties).to eq(headers: { gem: { foo: "bar" }, spec: { foo: "changed" } },
+                                          gemstash_resource_version: Gemstash::Resource::VERSION)
+      end
+
       it "can be deleted" do
         resource = storage.resource(resource_id)
         resource.delete(:content)

--- a/spec/gemstash/web_spec.rb
+++ b/spec/gemstash/web_spec.rb
@@ -163,11 +163,18 @@ describe Gemstash::Web do
       let(:upstream) { Gemstash::Upstream.new(current_env.config[:rubygems_url]) }
       let(:storage) { Gemstash::Storage.for("gem_cache").for(upstream.host_id) }
 
-      it "fetchs the gem file, stores, and serves it" do
+      it "fetches the gem file, stores, and serves it" do
         get "/gems/rack", {}, rack_env
         expect(last_response.body).to eq("zapatito")
         expect(last_response.header["CONTENT-TYPE"]).to eq("octet/stream")
         expect(storage.resource("rack").exist?(:gem)).to be_truthy
+      end
+
+      it "keeps the upstream and full gem name in the properties" do
+        get "/gems/rack-1.0.0.gem", {}, rack_env
+        properties = storage.resource("rack-1.0.0").properties
+        expect(properties[:upstream]).to eq(upstream.to_s)
+        expect(properties[:gem_name]).to eq("rack-1.0.0")
       end
 
       it "keeps headers for specs that have been previously fetched" do
@@ -249,11 +256,18 @@ describe Gemstash::Web do
       let(:upstream) { Gemstash::Upstream.new(current_env.config[:rubygems_url]) }
       let(:storage) { Gemstash::Storage.for("gem_cache").for(upstream.host_id) }
 
-      it "fetchs the marshalled gemspec, stores, and serves it" do
+      it "fetches the marshalled gemspec, stores, and serves it" do
         get "/quick/Marshal.4.8/rack.gemspec.rz", {}, rack_env
         expect(last_response.body).to eq("specatito")
         expect(last_response.header["CONTENT-TYPE"]).to eq("octet/stream")
         expect(storage.resource("rack").exist?(:spec)).to be_truthy
+      end
+
+      it "keeps the upstream and full gem name in the properties" do
+        get "/quick/Marshal.4.8/rack-1.0.0.gemspec.rz", {}, rack_env
+        properties = storage.resource("rack-1.0.0").properties
+        expect(properties[:upstream]).to eq(upstream.to_s)
+        expect(properties[:gem_name]).to eq("rack-1.0.0")
       end
 
       it "keeps headers for gems that have been previously fetched" do

--- a/spec/gemstash/web_spec.rb
+++ b/spec/gemstash/web_spec.rb
@@ -170,6 +170,13 @@ describe Gemstash::Web do
         expect(storage.resource("rack").exist?(:gem)).to be_truthy
       end
 
+      it "keeps headers for specs that have been previously fetched" do
+        get "/quick/Marshal.4.8/rack.gemspec.rz", {}, rack_env
+        get "/gems/rack", {}, rack_env
+        expect(storage.resource("rack").properties[:headers][:spec]).to be
+        expect(storage.resource("rack").properties[:headers][:gem]).to be
+      end
+
       it "indexes the cached gem" do
         get "/gems/rack", {}, rack_env
         db_upstream = Gemstash::DB::Upstream[uri: upstream.to_s]
@@ -247,6 +254,13 @@ describe Gemstash::Web do
         expect(last_response.body).to eq("specatito")
         expect(last_response.header["CONTENT-TYPE"]).to eq("octet/stream")
         expect(storage.resource("rack").exist?(:spec)).to be_truthy
+      end
+
+      it "keeps headers for gems that have been previously fetched" do
+        get "/gems/rack", {}, rack_env
+        get "/quick/Marshal.4.8/rack.gemspec.rz", {}, rack_env
+        expect(storage.resource("rack").properties[:headers][:gem]).to be
+        expect(storage.resource("rack").properties[:headers][:spec]).to be
       end
 
       it "indexes the cached spec" do

--- a/spec/gemstash/web_spec.rb
+++ b/spec/gemstash/web_spec.rb
@@ -204,6 +204,16 @@ describe Gemstash::Web do
         get "/gems/rack", {}, rack_env
         get "/gems/rack", {}, rack_env
       end
+
+      it "can be called after the gem has been deleted" do
+        get "/gems/rack", {}, rack_env
+        storage.resource("rack").delete(:gem)
+        expect(storage.resource("rack").exist?(:gem)).to be_falsey
+        get "/gems/rack", {}, rack_env
+        expect(last_response.body).to eq("zapatito")
+        expect(last_response.header["CONTENT-TYPE"]).to eq("octet/stream")
+        expect(storage.resource("rack").exist?(:gem)).to be_truthy
+      end
     end
 
     context "from private gems" do
@@ -296,6 +306,16 @@ describe Gemstash::Web do
       it "can be called multiple times without error" do
         get "/quick/Marshal.4.8/rack.gemspec.rz", {}, rack_env
         get "/quick/Marshal.4.8/rack.gemspec.rz", {}, rack_env
+      end
+
+      it "can be called after the spec has been deleted" do
+        get "/quick/Marshal.4.8/rack.gemspec.rz", {}, rack_env
+        storage.resource("rack").delete(:spec)
+        expect(storage.resource("rack").exist?(:spec)).to be_falsey
+        get "/quick/Marshal.4.8/rack.gemspec.rz", {}, rack_env
+        expect(last_response.body).to eq("specatito")
+        expect(last_response.header["CONTENT-TYPE"]).to eq("octet/stream")
+        expect(storage.resource("rack").exist?(:spec)).to be_truthy
       end
     end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -100,7 +100,7 @@ describe "gemstash integration tests" do
         @gemstash.env.cache.flush
       end
 
-      it "pushes valid gems to the server", :db_transaction => false do
+      it "pushes valid gems to the server", db_transaction: false do
         env = { "HOME" => env_dir }
         expect(execute("gem", ["push", "--key", "test", "--host", host, gem], env: env)).to exit_success
         expect(deps.fetch(%w(speaker))).to match_dependencies([speaker_deps])
@@ -116,7 +116,7 @@ describe "gemstash integration tests" do
         @gemstash.env.cache.flush
       end
 
-      it "removes valid gems from the server", :db_transaction => false do
+      it "removes valid gems from the server", db_transaction: false do
         env = { "HOME" => env_dir, "RUBYGEMS_HOST" => host }
         expect(execute("gem", ["yank", "--key", "test", gem_name, "--version", gem_version], env: env)).to exit_success
         expect(deps.fetch(%w(speaker))).to match_dependencies([])
@@ -135,7 +135,7 @@ describe "gemstash integration tests" do
         @gemstash.env.cache.flush
       end
 
-      it "adds valid gems back to the server", :db_transaction => false do
+      it "adds valid gems back to the server", db_transaction: false do
         env = { "HOME" => env_dir, "RUBYGEMS_HOST" => host }
         expect(execute("gem", ["yank", "--key", "test", gem_name, "--version", gem_version, "--undo"], env: env)).
           to exit_success
@@ -189,18 +189,18 @@ describe "gemstash integration tests" do
       end
     end
 
-    context "with default upstream gems" do
+    context "with default upstream gems", db_transaction: false do
       let(:bundle) { "integration_spec/default_upstream_gems" }
       it_behaves_like "a bundleable project"
     end
 
     # This should stay skipped until bundler sends the X-Gemfile-Source header
-    context "with upstream gems via a header mirror" do
+    context "with upstream gems via a header mirror", db_transaction: false do
       let(:bundle) { "integration_spec/header_mirror_gems" }
       it_behaves_like "a bundleable project"
     end
 
-    context "with upstream gems" do
+    context "with upstream gems", db_transaction: false do
       let(:bundle) { "integration_spec/upstream_gems" }
       it_behaves_like "a bundleable project"
 
@@ -222,7 +222,7 @@ describe "gemstash integration tests" do
       it_behaves_like "a bundleable project"
     end
 
-    context "with private gems", :db_transaction => false do
+    context "with private gems", db_transaction: false do
       before do
         Gemstash::Authorization.authorize("test-key", "all")
         Gemstash::GemPusher.new("test-key", read_gem("speaker", "0.1.0")).push


### PR DESCRIPTION
Store upstream and gem name of cached gems in the database, which will allow plugins to know what gems have been cached, and easily access them.

This also fixes a bug where headers from the spec would override the headers from the gem and vice versa.