### PR TITLE
Allow log_file to be configured, default to server.log in base dir

### DIFF
--- a/lib/gemstash/cli/authorize.rb
+++ b/lib/gemstash/cli/authorize.rb
@@ -20,7 +20,7 @@ module Gemstash
     private
 
       def setup_logging
-        Gemstash::Logging.setup_logger(gemstash_env.base_file("server.log"))
+        Gemstash::Logging.setup_logger(gemstash_env.log_file)
       end
 
       def remove_authorization

--- a/lib/gemstash/cli/start.rb
+++ b/lib/gemstash/cli/start.rb
@@ -18,7 +18,7 @@ module Gemstash
 
       def setup_logging
         return unless daemonize?
-        Gemstash::Logging.setup_logger(gemstash_env.base_file("server.log"))
+        Gemstash::Logging.setup_logger(gemstash_env.log_file)
       end
 
       def store_daemonized

--- a/lib/gemstash/env.rb
+++ b/lib/gemstash/env.rb
@@ -98,6 +98,10 @@ module Gemstash
       File.join(base_path, path)
     end
 
+    def log_file
+      base_file(config[:log_file] || "server.log")
+    end
+
     def rackup
       File.expand_path("../config.ru", __FILE__)
     end

--- a/spec/gemstash/env_spec.rb
+++ b/spec/gemstash/env_spec.rb
@@ -11,5 +11,17 @@ describe Gemstash::Env do
       expect { env.base_path }.to raise_error("Base path '#{dir}' is not writable")
       expect { env.base_file("example.txt") }.to raise_error("Base path '#{dir}' is not writable")
     end
+
+    it "defaults the log file to server.log" do
+      expect(env.log_file).to eq(env.base_file("server.log"))
+    end
+
+    it "can override the default log file location" do
+      Dir.mktmpdir do |dir|
+        log_file = File.join(dir, "server.log")
+        env.config = Gemstash::Configuration.new(config: { :log_file => log_file })
+        expect(env.log_file).to eq(env.base_file(log_file))
+      end
+    end
   end
 end


### PR DESCRIPTION
We deploy gemstash to our continuous delivery server and would like to have it log to something other than the default location. This small change adds support for a config option ```:log_file``` that overrides the default log file location.