### PR TITLE
Don't pass along the Content-Length header

### DIFF
--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -45,5 +45,5 @@ you push your own private gems as well."
   spec.add_development_dependency "rack-test", "~> 0.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "rubocop", "~> 0.34"
+  spec.add_development_dependency "rubocop", "0.35.1"
 end

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -120,10 +120,17 @@ module Gemstash
 
       def serve_cached(id, resource_type)
         gem = fetch_gem(id, resource_type)
-        headers.update(gem.properties[:headers][resource_type]) if gem.property?(:headers, resource_type)
+        set_gem_headers(gem, resource_type)
         gem.content(resource_type)
       rescue Gemstash::WebError => e
         halt e.code
+      end
+
+      def set_gem_headers(gem, resource_type)
+        return unless gem.property?(:headers, resource_type)
+        headers = gem.properties[:headers][resource_type]
+        headers = headers.reject { |key, _| key =~ /\Acontent-length\z/i }
+        headers.update(headers)
       end
 
       def dependencies

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -128,9 +128,10 @@ module Gemstash
 
       def set_gem_headers(gem, resource_type)
         return unless gem.property?(:headers, resource_type)
-        headers = gem.properties[:headers][resource_type]
-        headers = headers.reject { |key, _| key =~ /\Acontent-length\z/i }
-        headers.update(headers)
+        gem_headers = gem.properties[:headers][resource_type]
+        headers["Content-Type"] = gem_headers["content-type"] if gem_headers.include?("content-type")
+        headers["Last-Modified"] = gem_headers["last-modified"] if gem_headers.include?("last-modified")
+        headers["ETag"] = gem_headers["etag"] if gem_headers.include?("etag")
       end
 
       def dependencies


### PR DESCRIPTION
With the latest version of `Puma`, [this line](https://github.com/puma/puma/blob/642ca4f6cb9a0cf7e9174809fb0d78357f9e2ee4/lib/puma/server.rb#L613) is giving us problems from [this commit](https://github.com/puma/puma/commit/642ca4f6cb9a0cf7e9174809fb0d78357f9e2ee4).  Specifically, we are setting a `Content-Length` with a downcased header name. Before that commit in `Puma`, the normal cased version of the `Content-Length` header would be the only thing that triggered the line, but now the downcased version will as well. This in turn causes `Puma` to blow up. This is easily fixed by not passing along the `Content-Length` header we stashed from RubyGems.org. I suspect the content length is somehow differing from what should be sent... maybe a different bug in our code, or a bug somewhere in `Puma` when the content length is being sent. Regardless, this fixes the bug appearing in the specs.

Additionally, this was causing a bug for @chriseckhardt where gems would download and appear to be corrupted. This fix in turn fixes that bug as well as the spec failures with the latest `Puma`.