### PR TITLE
Support ERB parsing in YAML config

### DIFF
--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -1,4 +1,5 @@
 require "yaml"
+require "erb"
 
 module Gemstash
   #:nodoc:
@@ -31,7 +32,7 @@ module Gemstash
       file ||= DEFAULT_FILE
 
       if File.exist?(file)
-        @config = YAML.load_file(file)
+        @config = YAML.load(::ERB.new(File.read(file)).result)
         @config = DEFAULTS.merge(@config)
         @config.freeze
       else


### PR DESCRIPTION
Ideally, we don't want to have configuration hardcoded and checked in source control.
This change will allow users to fetch config from environment variables and make it easier to deploy Gemstash into different environments.