### PR TITLE
Add better error messaging when the resources do not have a version recorded

### DIFF
--- a/lib/gemstash/storage.rb
+++ b/lib/gemstash/storage.rb
@@ -275,7 +275,9 @@ module Gemstash
     end
 
     def check_resource_version
-      version = @properties[:gemstash_resource_version]
+      version = @properties.fetch(:gemstash_resource_version) do
+        raise "Resources are too old and don't have version, please wipe the cache directory"
+      end
       return if version <= Gemstash::Resource::VERSION
       reset
       raise Gemstash::Resource::VersionTooNew.new(name, folder, version)


### PR DESCRIPTION
I just run into this, my cache was too old and gemstash crashed with a _Nil does not define the method <=_

So I just added a simple way of logging a meaningful message.

cc/ @smellsblue 