### PR TITLE
Add fallback timeout documentation for when Gemstash's off/missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,24 @@ $ rm -rf Gemfile.lock .bundle
 $ bundle
 ```
 
+### Falling back to rubygems.org
+
+If you want to make sure that your bundling from https://rubygems.org still
+works as expected when the Gemstash server is not running, you can easily 
+configure Bundler to fallback to https://rubygems.org.
+
+```
+bundle config mirror.https://rubygems.org.fallback_timeout true
+```
+
+You can also configure this fallback as a number of seconds in case the Gemstash
+server is simply unresponsive.
+This example uses a 3 second timeout:
+
+```
+bundle config mirror.https://rubygems.org.fallback_timeout 3
+```
+
 ### Stopping the Server
 
 Once you've finish using your Gemstash server, you can stop it just as easily as


### PR DESCRIPTION
Per bundler/bundler#4186 this documents how to add a fallback timeout to prevent this happening when Gemstash is off:

```
$ bundle update
Fetching source index from http://localhost:9292/
Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from http://localhost:9292/
Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from http://localhost:9292/
Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from http://localhost:9292/
Could not fetch specs from http://localhost:9292/
```

After configuring a fallback, as described:

```
$ bundle config mirror.https://rubygems.org.fallback_timeout true
```

Instead, after trying Gemstash first and quickly failing, we see this:

```
$ bundle update
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Fetching dependency metadata from https://rubygems.org/
```

So we can see that it skips to using https://rubygems.org instead. 

Now, Gemstash seems much more like a viable option for a mirror!