### PR TITLE
Expanded - Support ERB parsing in YAML config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -116,18 +116,6 @@ This maps directly to the [Puma bind
 flag](https://github.com/puma/puma#binding-tcp--sockets), and will support
 anything valid for that flag.
 
-## Environment Variables
-
-You may also create a `~/.gemstash/config.yml.erb` file. If present this will be used instead of `~/.gemstash/config.yml`.
-With this you can use Environment Variables in the config:
-
-```yaml
-# ~/.gemstash/config.yml
----
-:db_adapter: postgres
-:db_url: <%= DATABASE_URL %>
-```
-
 ## Config File Location
 
 By default, configuration for Gemstash will be at `~/.gemstash/config.yml`. This
@@ -146,3 +134,15 @@ output to with the provided configuration. **This will overwrite** any existing
 configuration. If the file doesn't exist when providing `--config-file` to
 `gemstash start`, `gemstash stop`, `gemstash status`, and `gemstash authorize`,
 the default configuration will be used.
+
+### ERB parsed config
+
+You may also create a `~/.gemstash/config.yml.erb` file. If present this will be used instead of `~/.gemstash/config.yml`.
+For example with this you can use Environment Variables in the config:
+
+```yaml
+# ~/.gemstash/config.yml.erb
+---
+:db_adapter: postgres
+:db_url: <%= ENV["DATABASE_URL"] %>
+```

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,7 +23,7 @@ Checking that the database is available
 The database is not available
 </pre>
 
-Once you've answered the questsions, some checks will be made to ensure the
+Once you've answered the questions, some checks will be made to ensure the
 configuration will work. For example, the database didn't exist in the previous
 example, so the command failed and the configuration wasn't saved. If the
 command passes, you may provide the `--redo` option to force configuration to be
@@ -115,6 +115,18 @@ changed. To change the binding, update the `:bind` configuration key:
 This maps directly to the [Puma bind
 flag](https://github.com/puma/puma#binding-tcp--sockets), and will support
 anything valid for that flag.
+
+## Environment Variables
+
+You may also create a `~/.gemstash/config.yml.erb` file. If present this will be used instead of `~/.gemstash/config.yml`.
+With this you can use Environment Variables in the config:
+
+```yaml
+# ~/.gemstash/config.yml
+---
+:db_adapter: postgres
+:db_url: <%= DATABASE_URL %>
+```
 
 ## Config File Location
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -173,7 +173,7 @@ of Gemstash).
 
 **Description**<br />
 Specify the config file to use. If you aren't using the default config file at
-`~/.gemstash/config.yml`, then you must specify the config file via this option.
+`~/.gemstash/config.yml` or [`~/.gemstash/config.yml.erb`](https://github.com/bundler/gemstash/blob/master/docs/config.md#erb-parsed-config)), then you must specify the config file via this option.
 
 #### --key
 
@@ -213,7 +213,7 @@ gemstash start --no-daemonize
 
 **Description**<br />
 Specify the config file to use. If you aren't using the default config file at
-`~/.gemstash/config.yml`, then you must specify the config file via this option.
+`~/.gemstash/config.yml` (or [`~/.gemstash/config.yml.erb`](https://github.com/bundler/gemstash/blob/master/docs/config.md#erb-parsed-config)), then you must specify the config file via this option.
 
 #### --no-daemonize
 
@@ -242,7 +242,7 @@ gemstash stop
 
 **Description**<br />
 Specify the config file to use. If you aren't using the default config file at
-`~/.gemstash/config.yml`, then you must specify the config file via this option.
+`~/.gemstash/config.yml` or [`~/.gemstash/config.yml.erb`](https://github.com/bundler/gemstash/blob/master/docs/config.md#erb-parsed-config)), then you must specify the config file via this option.
 
 ## Status
 
@@ -262,7 +262,7 @@ gemstash status
 
 **Description**<br />
 Specify the config file to use. If you aren't using the default config file at
-`~/.gemstash/config.yml`, then you must specify the config file via this option.
+`~/.gemstash/config.yml` or [`~/.gemstash/config.yml.erb`](https://github.com/bundler/gemstash/blob/master/docs/config.md#erb-parsed-config)), then you must specify the config file via this option.
 
 ## Setup
 
@@ -303,7 +303,7 @@ This will do nothing if all checks pass.
 
 **Description**<br />
 Specify the config file to write to. Without this option, your configuration
-will be written to `~/.gemstash/config.yml`. If you write to a custom location,
+will be written to `~/.gemstash/config.yml` or [`~/.gemstash/config.yml.erb`](https://github.com/bundler/gemstash/blob/master/docs/config.md#erb-parsed-config)). If you write to a custom location,
 you will need to pass the `--config-file` option to all Gemstash commands.
 
 ## Version

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -32,11 +32,7 @@ module Gemstash
       file ||= DEFAULT_FILE
 
       if File.exist?(file)
-        if File.fnmatch?("**.erb", file)
-          @config = YAML.load(::ERB.new(File.read(file)).result)
-        else
-          @config = YAML.load_file(file)
-        end
+        @config = parse_config(file)
         @config = DEFAULTS.merge(@config)
         @config.freeze
       else
@@ -50,6 +46,16 @@ module Gemstash
 
     def [](key)
       @config[key]
+    end
+
+  private
+
+    def parse_config(file)
+      if File.fnmatch?("**.erb", file)
+        @config = YAML.load(::ERB.new(File.read(file)).result)
+      else
+        @config = YAML.load_file(file)
+      end
     end
   end
 end

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -55,8 +55,8 @@ module Gemstash
     end
 
     def parse_config(file)
-      if File.fnmatch?("**.erb", file)
-        @config = YAML.load(::ERB.new(File.read(file)).result)
+      if file.end_with?(".erb")
+        @config = YAML.load(ERB.new(File.read(file)).result)
       else
         @config = YAML.load_file(file)
       end

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -1,4 +1,5 @@
 require "yaml"
+require "erb"
 
 module Gemstash
   #:nodoc:
@@ -31,7 +32,7 @@ module Gemstash
       file ||= DEFAULT_FILE
 
       if File.exist?(file)
-        @config = YAML.load_file(file)
+        @config = YAML.load(::ERB.new(File.read(file)).result)
         @config = DEFAULTS.merge(@config)
         @config.freeze
       else

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -32,7 +32,11 @@ module Gemstash
       file ||= DEFAULT_FILE
 
       if File.exist?(file)
-        @config = YAML.load(::ERB.new(File.read(file)).result)
+        if File.fnmatch?("**.erb", file)
+          @config = YAML.load(::ERB.new(File.read(file)).result)
+        else
+          @config = YAML.load_file(file)
+        end
         @config = DEFAULTS.merge(@config)
         @config.freeze
       else

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -29,7 +29,7 @@ module Gemstash
       end
 
       raise MissingFileError, file if file && !File.exist?(file)
-      file ||= DEFAULT_FILE
+      file ||= default_file
 
       if File.exist?(file)
         @config = parse_config(file)
@@ -49,6 +49,10 @@ module Gemstash
     end
 
   private
+
+    def default_file
+      File.exist?("#{DEFAULT_FILE}.erb") ? "#{DEFAULT_FILE}.erb" : DEFAULT_FILE
+    end
 
     def parse_config(file)
       if File.fnmatch?("**.erb", file)

--- a/spec/data/configurations/configuration_spec/config.yml
+++ b/spec/data/configurations/configuration_spec/config.yml
@@ -1,0 +1,6 @@
+---
+:base_path: "/var/gemstash"
+:cache_type: memcached
+:memcached_servers: localhost:11211
+:db_adapter: postgres
+:db_url: postgres://gemstash

--- a/spec/data/configurations/configuration_spec/config.yml.erb
+++ b/spec/data/configurations/configuration_spec/config.yml.erb
@@ -1,0 +1,6 @@
+---
+:base_path: "/var/gemstash"
+:cache_type: memcached
+:memcached_servers: localhost:11211
+:db_adapter: postgres
+:db_url: <%= ENV["DATABASE_URL"] %>

--- a/spec/gemstash/configuration_spec.rb
+++ b/spec/gemstash/configuration_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+describe Gemstash::Configuration do
+  let(:config_dir) { config_path("configuration_spec") }
+
+  context "no config file" do
+    let(:env) { Gemstash::Env.new }
+
+    it "loads the default config" do
+      expect(env.config[:db_adapter]).to eq("sqlite3")
+    end
+  end
+
+  context "erb config file" do
+    before do
+      ENV["DATABASE_URL"] = "postgres://rendered-erb"
+    end
+    let(:config) { Gemstash::Configuration.new(file: "#{config_dir}/config.yml.erb") }
+    let(:env) { Gemstash::Env.new(config) }
+
+    it "interprets the erb, loads yaml and merges with defaults" do
+      expect(env.config[:db_adapter]).to eq("postgres")
+      expect(env.config[:db_url]).to eq("postgres://rendered-erb")
+    end
+  end
+
+  context "plain yaml config file" do
+    let(:config) { Gemstash::Configuration.new(file: "#{config_dir}/config.yml") }
+    let(:env) { Gemstash::Env.new(config) }
+
+    it "merges the yaml config with defaults" do
+      expect(env.config[:db_adapter]).to eq("postgres")
+      expect(env.config[:db_url]).to eq("postgres://gemstash")
+    end
+  end
+end

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -24,6 +24,11 @@ module FileHelpers
     File.join(bundles_dir, name)
   end
 
+  def config_path(name)
+    configs_dir = File.expand_path("../../data/configurations", __FILE__)
+    File.join(configs_dir, name)
+  end
+
   def clean_bundle(name)
     dir = bundle_path(name)
     lock_file = File.join(dir, "Gemfile.lock")


### PR DESCRIPTION
This supersedes #86

The main use-case for this is using Environment variables in config. 

In this PR:

* If a config file has the suffix `.erb` (specified on the command line or exists e.g. `~/.gemstash/config.yml.erb` this is parsed and merged with the defaults.
* Default file: load `config.yml.erb` then try `config.yml`
* Specs for this feature (also basic specs for plain yaml and no config file)
* Basic docs centered around the Environment variables use case.
