### PR TITLE
Expanded - Refactor authorization - Add protected fetch for private gems

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -116,6 +116,19 @@ This maps directly to the [Puma bind
 flag](https://github.com/puma/puma#binding-tcp--sockets), and will support
 anything valid for that flag.
 
+## Protected Fetch
+
+Gemstash by default allows un-authenticated access for Private gems. Authenticated access is available via the `:protected_fetch` configuration key.
+
+
+```yaml
+# ~/.gemstash/config.yml
+---
+:protected_fetch: true
+```
+
+More details on [protected_fetch are here](https://github.com/bundler/gemstash/blob/master/docs/private_gems.md#protected-fetching).
+
 ## Config File Location
 
 By default, configuration for Gemstash will be at `~/.gemstash/config.yml`. This

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -11,6 +11,7 @@ Table of Contents
       * [:db_url](#db_url)
       * [:rubygems_url](#rubygems_url)
       * [:bind](#bind)
+      * [:protected_fetch](#protected_fetch)
     * [Authorize](#authorize)
       * [Usage](#usage)
       * [Arguments](#arguments)
@@ -59,6 +60,7 @@ Table of Contents
 :db_url: postgres:///gemstash
 :rubygems_url: https://my.gem-source.local
 :bind: tcp://0.0.0.0:4242
+:protected_fetch: true
 ```
 
 ### :base_path
@@ -145,6 +147,15 @@ Specifies the binding used to start the Gemstash server. Keep in mind the user
 starting Gemstash needs to have access to bind in this manner. For example, if
 you use a port below 1024, you will need to run Gemstash as the root user.
 
+### :protected_fetch
+
+**Default value:** `false`
+
+**Valid values:** Boolean values `true` or `false`
+
+**Description**<br />
+Tells Gemstash to authenticate via API Key before allowing the fetching of Private gems and specs. Default is un-authenticated download of Private gems and specs.
+
 ## Authorize
 
 Adds or removes authorization to interact with privately stored gems.
@@ -161,7 +172,7 @@ gemstash authorize --remove --key <secure-key>
 ### Arguments
 
 Any arguments will be used as specific permissions. Valid permissions include
-`push`, `yank`, and `unyank`. If no permissions are provided, then all
+`push`, `yank`, `unyank`, and `fetch`. If no permissions are provided, then all
 permissions will be granted (including any that may be added in future versions
 of Gemstash).
 

--- a/lib/gemstash/api_key_authorization.rb
+++ b/lib/gemstash/api_key_authorization.rb
@@ -7,9 +7,14 @@ module Gemstash
       @key = key
     end
 
-    def self.serve(server, app, request, params)
+    def self.protect(app, request, &block)
       key = request.env["HTTP_AUTHORIZATION"]
-      server.serve(new(key), request, params)
+      auth = new(key)
+      if block_given?
+        yield auth
+      else
+        auth
+      end
     rescue Gemstash::NotAuthorizedError => e
       app.headers["WWW-Authenticate"] = "Basic realm=\"Gemstash Private Gems\""
       app.halt 401, e.message

--- a/lib/gemstash/api_key_authorization.rb
+++ b/lib/gemstash/api_key_authorization.rb
@@ -7,10 +7,10 @@ module Gemstash
       @key = key
     end
 
-    def self.serve(app, servable)
+    def self.protect(app, &block)
       key = app.request.env["HTTP_AUTHORIZATION"]
       app.auth = new(key)
-      servable.serve(app)
+      yield
     rescue Gemstash::NotAuthorizedError => e
       app.headers["WWW-Authenticate"] = "Basic realm=\"Gemstash Private Gems\""
       app.halt 401, e.message

--- a/lib/gemstash/authorization.rb
+++ b/lib/gemstash/authorization.rb
@@ -9,7 +9,7 @@ module Gemstash
   class Authorization
     extend Gemstash::Env::Helper
     extend Gemstash::Logging
-    VALID_PERMISSIONS = %w(push yank unyank).freeze
+    VALID_PERMISSIONS = %w(push yank unyank fetch).freeze
 
     def self.authorize(auth_key, permissions)
       raise "Authorization key is required!" if auth_key.to_s.strip.empty?
@@ -82,6 +82,10 @@ module Gemstash
 
     def unyank?
       can?("unyank")
+    end
+
+    def fetch?
+      can?("fetch")
     end
   end
 end

--- a/lib/gemstash/cli/setup.rb
+++ b/lib/gemstash/cli/setup.rb
@@ -22,6 +22,7 @@ module Gemstash
         ask_storage
         ask_cache
         ask_database
+        ask_protected_fetch
         check_cache
         check_storage
         check_database
@@ -99,6 +100,14 @@ module Gemstash
         url = @cli.ask "Where is the database? [#{default_value}]"
         url = default_value if url.empty?
         @config[:db_url] = url
+      end
+
+      def ask_protected_fetch
+        say_current_config(:protected_fetch, "Protected Fetch enabled")
+
+        value = @cli.yes? "Use Protected Fetch for Private Gems? [y/N]"
+        value = Gemstash::Configuration::DEFAULTS[:protected_fetch] if value.is_a?(String) && value.empty?
+        @config[:protected_fetch] = value
       end
 
       def check_cache

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -9,7 +9,8 @@ module Gemstash
       :base_path => File.expand_path("~/.gemstash"),
       :db_adapter => "sqlite3",
       :bind => "tcp://0.0.0.0:9292",
-      :rubygems_url => "https://www.rubygems.org"
+      :rubygems_url => "https://www.rubygems.org",
+      :protected_fetch => false
     }.freeze
 
     DEFAULT_FILE = File.expand_path("~/.gemstash/config.yml").freeze

--- a/lib/gemstash/gem_source/private_source.rb
+++ b/lib/gemstash/gem_source/private_source.rb
@@ -24,21 +24,15 @@ module Gemstash
       end
 
       def serve_add_gem
-        authorization.protect(self, request) do |auth|
-          Gemstash::GemPusher.serve(auth, request, params)
-        end
+        protected(Gemstash::GemPusher)
       end
 
       def serve_yank
-        authorization.protect(self, request) do |auth|
-          Gemstash::GemYanker.serve(auth, request, params)
-        end
+        protected(Gemstash::GemYanker)
       end
 
       def serve_unyank
-        authorization.protect(self, request) do |auth|
-          Gemstash::GemUnyanker.serve(auth, request, params)
-        end
+        protected(Gemstash::GemUnyanker)
       end
 
       def serve_add_spec_json
@@ -85,23 +79,19 @@ module Gemstash
       end
 
       def serve_specs
-        authorization.protect(self, request) do |auth|
-          content_type "application/octet-stream"
-          Gemstash::SpecsBuilder.all(auth)
-        end
+        params[:prerelease] = false
+        protected(Gemstash::SpecsBuilder)
       end
 
       def serve_prerelease_specs
-        authorization.protect(self, request) do |auth|
-          content_type "application/octet-stream"
-          Gemstash::SpecsBuilder.prerelease(auth)
-        end
+        params[:prerelease] = true
+        protected(Gemstash::SpecsBuilder)
       end
 
     private
 
-      def authenticated(servable)
-        authorization.serve(self, servable)
+      def protected(servable)
+        authorization.protect(self) { servable.serve(self) }
       end
 
       def authorization

--- a/lib/gemstash/gem_source/private_source.rb
+++ b/lib/gemstash/gem_source/private_source.rb
@@ -23,15 +23,21 @@ module Gemstash
       end
 
       def serve_add_gem
-        authenticated(Gemstash::GemPusher)
+        authorization.protect(self, request) do |auth|
+          Gemstash::GemPusher.serve(auth, request, params)
+        end
       end
 
       def serve_yank
-        authenticated(Gemstash::GemYanker)
+        authorization.protect(self, request) do |auth|
+          Gemstash::GemYanker.serve(auth, request, params)
+        end
       end
 
       def serve_unyank
-        authenticated(Gemstash::GemUnyanker)
+        authorization.protect(self, request) do |auth|
+          Gemstash::GemUnyanker.serve(auth, request, params)
+        end
       end
 
       def serve_add_spec_json
@@ -78,20 +84,20 @@ module Gemstash
       end
 
       def serve_specs
-        content_type "application/octet-stream"
-        Gemstash::SpecsBuilder.all
+        authorization.protect(self, request) do |auth|
+          content_type "application/octet-stream"
+          Gemstash::SpecsBuilder.all(auth)
+        end
       end
 
       def serve_prerelease_specs
-        content_type "application/octet-stream"
-        Gemstash::SpecsBuilder.prerelease
+        authorization.protect(self, request) do |auth|
+          content_type "application/octet-stream"
+          Gemstash::SpecsBuilder.prerelease(auth)
+        end
       end
 
     private
-
-      def authenticated(server)
-        authorization.serve(server, self, request, params)
-      end
 
       def authorization
         Gemstash::ApiKeyAuthorization

--- a/lib/gemstash/gem_source/private_source.rb
+++ b/lib/gemstash/gem_source/private_source.rb
@@ -56,11 +56,14 @@ module Gemstash
       end
 
       def serve_marshal(id)
-        gem_full_name = id.sub(/\.gemspec\.rz\z/, "")
-        gem = fetch_gem(gem_full_name)
-        halt 404 unless gem.exist?(:spec)
-        content_type "application/octet-stream"
-        gem.content(:spec)
+        authorization.protect(self) do
+          auth.check("fetch") if gemstash_env.config[:protected_fetch]
+          gem_full_name = id.sub(/\.gemspec\.rz\z/, "")
+          gem = fetch_gem(gem_full_name)
+          halt 404 unless gem.exist?(:spec)
+          content_type "application/octet-stream"
+          gem.content(:spec)
+        end
       end
 
       def serve_actual_gem(id)
@@ -68,10 +71,13 @@ module Gemstash
       end
 
       def serve_gem(id)
-        gem_full_name = id.sub(/\.gem\z/, "")
-        gem = fetch_gem(gem_full_name)
-        content_type "application/octet-stream"
-        gem.content(:gem)
+        authorization.protect(self) do
+          auth.check("fetch") if gemstash_env.config[:protected_fetch]
+          gem_full_name = id.sub(/\.gem\z/, "")
+          gem = fetch_gem(gem_full_name)
+          content_type "application/octet-stream"
+          gem.content(:gem)
+        end
       end
 
       def serve_latest_specs

--- a/spec/gemstash/authorization_spec.rb
+++ b/spec/gemstash/authorization_spec.rb
@@ -164,6 +164,7 @@ describe Gemstash::Authorization do
         expect(auth.push?).to be_truthy
         expect(auth.yank?).to be_truthy
         expect(auth.unyank?).to be_truthy
+        expect(auth.fetch?).to be_truthy
       end
     end
 
@@ -175,13 +176,15 @@ describe Gemstash::Authorization do
         expect(auth.push?).to be_truthy
         expect(auth.yank?).to be_truthy
         expect(auth.unyank?).to be_falsey
+        expect(auth.fetch?).to be_falsey
 
-        Gemstash::Authorization.authorize("abc", %w(yank unyank))
+        Gemstash::Authorization.authorize("abc", %w(yank unyank fetch))
         auth = Gemstash::Authorization["abc"]
         expect(auth.all?).to be_falsey
         expect(auth.push?).to be_falsey
         expect(auth.yank?).to be_truthy
         expect(auth.unyank?).to be_truthy
+        expect(auth.fetch?).to be_truthy
       end
     end
   end

--- a/spec/gemstash/cli/setup_spec.rb
+++ b/spec/gemstash/cli/setup_spec.rb
@@ -29,6 +29,7 @@ describe Gemstash::CLI::Setup do
   context "accepting all defaults" do
     it "saves the config with defaults" do
       allow(cli).to receive(:ask).and_return("")
+      allow(cli).to receive(:yes?).and_return("")
       expect(File.exist?(cli_options[:config_file])).to be_falsey
       # This is expected to touch the metadata file, which we don't want to
       # write out (it would go in ~/.gemstash rather than our test path)
@@ -50,6 +51,7 @@ describe Gemstash::CLI::Setup do
     it "errors immediately" do
       File.write metadata_path, metadata.to_yaml
       allow(cli).to receive(:ask).and_return("")
+      allow(cli).to receive(:yes?).and_return("")
       expect(cli).to receive(:ask).with("Where should files go? [~/.gemstash]", path: true).and_return(TEST_BASE_PATH)
       expect(File.exist?(cli_options[:config_file])).to be_falsey
       expect { Gemstash::CLI::Setup.new(cli).run }.to raise_error(Gemstash::CLI::Error, /newer version/)
@@ -60,8 +62,9 @@ describe Gemstash::CLI::Setup do
   context "with invalid cache setup" do
     let(:cache_client) { double }
 
-    it "errors when cehcking the cache" do
+    it "errors when checking the cache" do
       allow(cli).to receive(:ask).and_return("")
+      allow(cli).to receive(:yes?).and_return("")
       expect(cli).to receive(:ask).with("Where should files go? [~/.gemstash]", path: true).and_return(TEST_BASE_PATH)
       allow_any_instance_of(Gemstash::Env).to receive(:cache_client).and_return(cache_client)
       expect(cache_client).to receive(:alive!).and_raise("Invalid cache setup!")
@@ -74,8 +77,9 @@ describe Gemstash::CLI::Setup do
   context "with invalid database setup" do
     let(:database) { double }
 
-    it "errors when cehcking the cache" do
+    it "errors when checking the cache" do
       allow(cli).to receive(:ask).and_return("")
+      allow(cli).to receive(:yes?).and_return("")
       expect(cli).to receive(:ask).with("Where should files go? [~/.gemstash]", path: true).and_return(TEST_BASE_PATH)
       allow_any_instance_of(Gemstash::Env).to receive(:db).and_return(database)
       expect(database).to receive(:test_connection).and_raise("Invalid db setup!")

--- a/spec/gemstash/specs_builder_spec.rb
+++ b/spec/gemstash/specs_builder_spec.rb
@@ -15,12 +15,12 @@ describe Gemstash::SpecsBuilder do
 
   context "with no private gems" do
     it "returns an empty result" do
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to eq([])
     end
 
     it "returns an empty prerelease result" do
-      result = Gemstash::SpecsBuilder.prerelease(auth)
+      result = Gemstash::SpecsBuilder.new(auth, prerelease: true).serve
       expect(Marshal.load(gunzip(result))).to eq([])
     end
   end
@@ -43,12 +43,12 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "marshals and gzips the versions" do
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to match_array(expected_specs)
     end
 
     it "returns an empty prerelease result" do
-      result = Gemstash::SpecsBuilder.prerelease(auth)
+      result = Gemstash::SpecsBuilder.new(auth, prerelease: true).serve
       expect(Marshal.load(gunzip(result))).to eq([])
     end
   end
@@ -71,12 +71,12 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "returns an empty result" do
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to eq([])
     end
 
     it "marshals and gzips the prerelease versions" do
-      result = Gemstash::SpecsBuilder.prerelease(auth)
+      result = Gemstash::SpecsBuilder.new(auth, prerelease: true).serve
       expect(Marshal.load(gunzip(result))).to match_array(expected_prerelease_specs)
     end
   end
@@ -110,12 +110,12 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "marshals and gzips the versions" do
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to match_array(expected_specs)
     end
 
     it "marshals and gzips the prerelease versions" do
-      result = Gemstash::SpecsBuilder.prerelease(auth)
+      result = Gemstash::SpecsBuilder.new(auth, prerelease: true).serve
       expect(Marshal.load(gunzip(result))).to match_array(expected_prerelease_specs)
     end
   end
@@ -155,12 +155,12 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "marshals and gzips the versions" do
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to match_array(expected_specs)
     end
 
     it "marshals and gzips the prerelease versions" do
-      result = Gemstash::SpecsBuilder.prerelease(auth)
+      result = Gemstash::SpecsBuilder.new(auth, prerelease: true).serve
       expect(Marshal.load(gunzip(result))).to match_array(expected_prerelease_specs)
     end
   end
@@ -176,10 +176,10 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemPusher.new(auth, read_gem("example", "0.1.0")).serve
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_push)
     end
   end
@@ -195,10 +195,10 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.prerelease(auth)
+      result = Gemstash::SpecsBuilder.new(auth, prerelease: true).serve
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemPusher.new(auth, read_gem("example", "0.1.0.pre")).serve
-      result = Gemstash::SpecsBuilder.prerelease(auth)
+      result = Gemstash::SpecsBuilder.new(auth, prerelease: true).serve
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_push)
     end
   end
@@ -219,10 +219,10 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemYanker.new(auth, "example", "0.1.0").serve
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_yank)
     end
   end
@@ -243,10 +243,10 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.prerelease(auth)
+      result = Gemstash::SpecsBuilder.new(auth, prerelease: true).serve
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemYanker.new(auth, "example", "0.1.0.pre").serve
-      result = Gemstash::SpecsBuilder.prerelease(auth)
+      result = Gemstash::SpecsBuilder.new(auth, prerelease: true).serve
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_yank)
     end
   end
@@ -264,10 +264,10 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemUnyanker.new(auth, "example", "0.1.0").serve
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_unyank)
     end
   end
@@ -285,17 +285,17 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.prerelease(auth)
+      result = Gemstash::SpecsBuilder.new(auth, prerelease: true).serve
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemUnyanker.new(auth, "example", "0.1.0.pre").serve
-      result = Gemstash::SpecsBuilder.prerelease(auth)
+      result = Gemstash::SpecsBuilder.new(auth, prerelease: true).serve
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_unyank)
     end
   end
 
   context "with protected fetch disabled" do
     it "serves specs without authorization" do
-      result = Gemstash::SpecsBuilder.all(auth)
+      result = Gemstash::SpecsBuilder.new(auth).serve
       expect(Marshal.load(gunzip(result))).to eq([])
     end
   end
@@ -303,7 +303,7 @@ describe Gemstash::SpecsBuilder do
   context "with protected fetch enabled" do
     before do
       @test_env = test_env
-      config = Gemstash::Configuration.new(config: {protected_fetch: true})
+      config = Gemstash::Configuration.new(config: { protected_fetch: true })
       Gemstash::Env.current = Gemstash::Env.new(config)
     end
 
@@ -313,21 +313,21 @@ describe Gemstash::SpecsBuilder do
 
     context "with valid authorization" do
       it "serves specs" do
-        result = Gemstash::SpecsBuilder.all(auth)
+        result = Gemstash::SpecsBuilder.new(auth).serve
         expect(Marshal.load(gunzip(result))).to eq([])
       end
     end
 
     context "with invalid authorization" do
       it "prevents serving specs" do
-        expect { Gemstash::SpecsBuilder.all(auth_with_invalid_auth_key) }.
+        expect { Gemstash::SpecsBuilder.new(auth_with_invalid_auth_key).serve }.
           to raise_error(Gemstash::NotAuthorizedError)
       end
     end
 
     context "with invalid permission" do
       it "prevents serving specs" do
-        expect { Gemstash::SpecsBuilder.all(auth_without_permission) }.
+        expect { Gemstash::SpecsBuilder.new(auth_without_permission).serve }.
           to raise_error(Gemstash::NotAuthorizedError)
       end
     end

--- a/spec/gemstash/specs_builder_spec.rb
+++ b/spec/gemstash/specs_builder_spec.rb
@@ -2,16 +2,25 @@ require "spec_helper"
 
 describe Gemstash::SpecsBuilder do
   let(:auth) { Gemstash::ApiKeyAuthorization.new(auth_key) }
+  let(:auth_with_invalid_auth_key) { Gemstash::ApiKeyAuthorization.new(invalid_auth_key) }
+  let(:auth_without_permission) { Gemstash::ApiKeyAuthorization.new(auth_key_without_permission) }
   let(:auth_key) { "auth-key" }
+  let(:invalid_auth_key) { "invalid-auth-key" }
+  let(:auth_key_without_permission) { "auth-key-without-permission" }
+
+  before do
+    Gemstash::Authorization.authorize(auth_key, "all")
+    Gemstash::Authorization.authorize(auth_key_without_permission, ["push"])
+  end
 
   context "with no private gems" do
     it "returns an empty result" do
-      result = Gemstash::SpecsBuilder.all
+      result = Gemstash::SpecsBuilder.all(auth)
       expect(Marshal.load(gunzip(result))).to eq([])
     end
 
     it "returns an empty prerelease result" do
-      result = Gemstash::SpecsBuilder.prerelease
+      result = Gemstash::SpecsBuilder.prerelease(auth)
       expect(Marshal.load(gunzip(result))).to eq([])
     end
   end
@@ -34,12 +43,12 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "marshals and gzips the versions" do
-      result = Gemstash::SpecsBuilder.all
+      result = Gemstash::SpecsBuilder.all(auth)
       expect(Marshal.load(gunzip(result))).to match_array(expected_specs)
     end
 
     it "returns an empty prerelease result" do
-      result = Gemstash::SpecsBuilder.prerelease
+      result = Gemstash::SpecsBuilder.prerelease(auth)
       expect(Marshal.load(gunzip(result))).to eq([])
     end
   end
@@ -62,12 +71,12 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "returns an empty result" do
-      result = Gemstash::SpecsBuilder.all
+      result = Gemstash::SpecsBuilder.all(auth)
       expect(Marshal.load(gunzip(result))).to eq([])
     end
 
     it "marshals and gzips the prerelease versions" do
-      result = Gemstash::SpecsBuilder.prerelease
+      result = Gemstash::SpecsBuilder.prerelease(auth)
       expect(Marshal.load(gunzip(result))).to match_array(expected_prerelease_specs)
     end
   end
@@ -101,12 +110,12 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "marshals and gzips the versions" do
-      result = Gemstash::SpecsBuilder.all
+      result = Gemstash::SpecsBuilder.all(auth)
       expect(Marshal.load(gunzip(result))).to match_array(expected_specs)
     end
 
     it "marshals and gzips the prerelease versions" do
-      result = Gemstash::SpecsBuilder.prerelease
+      result = Gemstash::SpecsBuilder.prerelease(auth)
       expect(Marshal.load(gunzip(result))).to match_array(expected_prerelease_specs)
     end
   end
@@ -146,12 +155,12 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "marshals and gzips the versions" do
-      result = Gemstash::SpecsBuilder.all
+      result = Gemstash::SpecsBuilder.all(auth)
       expect(Marshal.load(gunzip(result))).to match_array(expected_specs)
     end
 
     it "marshals and gzips the prerelease versions" do
-      result = Gemstash::SpecsBuilder.prerelease
+      result = Gemstash::SpecsBuilder.prerelease(auth)
       expect(Marshal.load(gunzip(result))).to match_array(expected_prerelease_specs)
     end
   end
@@ -167,10 +176,10 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.all
+      result = Gemstash::SpecsBuilder.all(auth)
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemPusher.new(auth, read_gem("example", "0.1.0")).serve
-      result = Gemstash::SpecsBuilder.all
+      result = Gemstash::SpecsBuilder.all(auth)
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_push)
     end
   end
@@ -186,10 +195,10 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.prerelease
+      result = Gemstash::SpecsBuilder.prerelease(auth)
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemPusher.new(auth, read_gem("example", "0.1.0.pre")).serve
-      result = Gemstash::SpecsBuilder.prerelease
+      result = Gemstash::SpecsBuilder.prerelease(auth)
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_push)
     end
   end
@@ -210,10 +219,10 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.all
+      result = Gemstash::SpecsBuilder.all(auth)
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemYanker.new(auth, "example", "0.1.0").serve
-      result = Gemstash::SpecsBuilder.all
+      result = Gemstash::SpecsBuilder.all(auth)
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_yank)
     end
   end
@@ -234,10 +243,10 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.prerelease
+      result = Gemstash::SpecsBuilder.prerelease(auth)
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemYanker.new(auth, "example", "0.1.0.pre").serve
-      result = Gemstash::SpecsBuilder.prerelease
+      result = Gemstash::SpecsBuilder.prerelease(auth)
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_yank)
     end
   end
@@ -255,10 +264,10 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.all
+      result = Gemstash::SpecsBuilder.all(auth)
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemUnyanker.new(auth, "example", "0.1.0").serve
-      result = Gemstash::SpecsBuilder.all
+      result = Gemstash::SpecsBuilder.all(auth)
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_unyank)
     end
   end
@@ -276,11 +285,51 @@ describe Gemstash::SpecsBuilder do
     end
 
     it "busts the cache" do
-      result = Gemstash::SpecsBuilder.prerelease
+      result = Gemstash::SpecsBuilder.prerelease(auth)
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemUnyanker.new(auth, "example", "0.1.0.pre").serve
-      result = Gemstash::SpecsBuilder.prerelease
+      result = Gemstash::SpecsBuilder.prerelease(auth)
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_unyank)
+    end
+  end
+
+  context "with protected fetch disabled" do
+    it "serves specs without authorization" do
+      result = Gemstash::SpecsBuilder.all(auth)
+      expect(Marshal.load(gunzip(result))).to eq([])
+    end
+  end
+
+  context "with protected fetch enabled" do
+    before do
+      @test_env = test_env
+      config = Gemstash::Configuration.new(config: {protected_fetch: true})
+      Gemstash::Env.current = Gemstash::Env.new(config)
+    end
+
+    after do
+      Gemstash::Env.current = @test_env
+    end
+
+    context "with valid authorization" do
+      it "serves specs" do
+        result = Gemstash::SpecsBuilder.all(auth)
+        expect(Marshal.load(gunzip(result))).to eq([])
+      end
+    end
+
+    context "with invalid authorization" do
+      it "prevents serving specs" do
+        expect { Gemstash::SpecsBuilder.all(auth_with_invalid_auth_key) }.
+          to raise_error(Gemstash::NotAuthorizedError)
+      end
+    end
+
+    context "with invalid permission" do
+      it "prevents serving specs" do
+        expect { Gemstash::SpecsBuilder.all(auth_without_permission) }.
+          to raise_error(Gemstash::NotAuthorizedError)
+      end
     end
   end
 end


### PR DESCRIPTION
This builds on #92, #93 and resolves #24 

@smellsblue I think this covers off all your feedback - thanks!

This PR contains:

* Iteration on @smellsblue's work on the Authorization refactor
* `protected_fetch` (default false) in `Gemstash::Configuration`
* Configuration of `protected_fetch` via `$ gemstash setup`
* A new `fetch` permission for Authorization
* Authentication via HTTP Basic Auth (token as username) to support `gem`, `bundler` and uri based auth in `Gemfiles`
* Docs to suit.