### PR TITLE
Remove bundler-audit since we don't commit our Gemfile.lock

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,5 @@
 ---
 engines:
-  bundler-audit:
-    enabled: true
   duplication:
     enabled: true
     config:
@@ -13,7 +11,6 @@ engines:
     enabled: true
 ratings:
   paths:
-  - Gemfile.lock
   - "**.rb"
 exclude_paths:
 - spec/


### PR DESCRIPTION
Code Climate build [is failing](https://codeclimate.com/github/bundler/gemstash/builds/4) due to `bundler-audit` being enabled with no Gemfile.lock.

I think this might be valuable to add to our regular Travis build after Travis bundles... should I look into that?