### PR TITLE
Drop www.rubygems.org in favor of rubygems.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 ## What is Gemstash?
 
-Gemstash is both a cache for remote servers such as https://www.rubygems.org,
-and a private gem source.
+Gemstash is both a cache for remote servers such as https://rubygems.org, and a
+private gem source.
 
 If you are using [bundler](http://bundler.io/) across many machines that have
 access to a server within your control, you might want to use Gemstash.
@@ -17,7 +17,7 @@ you might want to use Gemstash.
 If you frequently bundle the same set of gems across multiple projects, you
 might want to use Gemstash.
 
-Are you only using gems from https://www.rubygems.org, and don't bundle the same
+Are you only using gems from https://rubygems.org, and don't bundle the same
 gems frequently? Well, maybe you don't need Gemstash... yet.
 
 ## Quickstart Guide
@@ -68,11 +68,11 @@ otherwise Gemstash will have nothing to stash. Now bundle:
 $ bundle install --path .bundle
 ```
 
-Your Gemstash server has fetched the gems from https://www.rubygems.org and
-cached them for you! To prove this, you can disable your Internet connection and
-try again. The gem dependencies from https://www.rubygems.org are cached for 30
-minutes, so if you bundle again before that, you can successfully bundle without
-an Internet connection:
+Your Gemstash server has fetched the gems from https://rubygems.org and cached
+them for you! To prove this, you can disable your Internet connection and try
+again. The gem dependencies from https://rubygems.org are cached for 30 minutes,
+so if you bundle again before that, you can successfully bundle without an
+Internet connection:
 
 ```
 $ # Disable your Internet first!
@@ -131,7 +131,7 @@ Gemstash temporarily caches things like gem dependencies in memory. Anything
 cached in memory will last for 30 minutes before being retrieved again. You can
 [use memcached](docs/config.md#cache) instead of caching in memory. Gem files
 are always cached permanently, so bundling with a `Gemfile.lock` with all gems
-cached will never call out to https://www.rubygems.org.
+cached will never call out to https://rubygems.org.
 
 The server you ran is provided via [Puma](http://puma.io/) and
 [Rack](http://rack.github.io/), however they are not customizable at this point.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -4,7 +4,7 @@ Bundler is here for the rescue to keep Gemstash up to date! Create a `Gemfile`
 pointing to Gemstash:
 ```ruby
 # ./Gemfile
-source "https://www.rubygems.org"
+source "https://rubygems.org"
 gem "gemstash"
 ```
 

--- a/docs/multiple_sources.md
+++ b/docs/multiple_sources.md
@@ -8,8 +8,8 @@ Gemstash server.
 
 When you don't provide an explicit source (as with the [Quickstart
 Guide](../README.md#quickstart-guide)), your gems will be fetched from
-https://www.rubygems.org. This default source is not set in stone. To change it,
-you need only edit the Gemstash configuration found at `~/.gemstash/config.yml`:
+https://rubygems.org. This default source is not set in stone. To change it, you
+need only edit the Gemstash configuration found at `~/.gemstash/config.yml`:
 ```yaml
 # ~/.gemstash/config.yml
 ---
@@ -30,9 +30,9 @@ separate location, ensuring different sources won't leak between each other.
 ## Bundling with Multiple Sources
 
 Changing the default source won't help you if you need to bundle against
-https://www.rubygems.org along with additional sources. If you need to bundle
-with multiple gem sources, Gemstash doesn't need to be specially configured.
-Your Gemstash server will honor any gem source specified via a specialized URL.
+https://rubygems.org along with additional sources. If you need to bundle with
+multiple gem sources, Gemstash doesn't need to be specially configured. Your
+Gemstash server will honor any gem source specified via a specialized URL.
 Consider the following `Gemfile`:
 ```ruby
 # ./Gemfile
@@ -58,7 +58,7 @@ your `Gemfile` like so:
 ```ruby
 # ./Gemfile
 require "cgi"
-source "http://localhost:9292/redirect/#{CGI.escape("https://www.rubygems.org")}"
+source "http://localhost:9292/redirect/#{CGI.escape("https://rubygems.org")}"
 gem "rubywarrior"
 ```
 

--- a/docs/private_gems.md
+++ b/docs/private_gems.md
@@ -36,7 +36,7 @@ $ gemstash authorize --key e374e237fdf5fa5718d2a21bd63dc911
 ```
 
 With the key generated, you'll need to tell Rubygems about your new key. If
-you've pushed a gem to https://www.rubygems.org, then you will already have a
+you've pushed a gem to https://rubygems.org, then you will already have a
 credentials file to add the key to. If not, run the following commands before
 modifying the credentials file:
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -125,7 +125,7 @@ Specifies the database to connect to when using `postgres` for the
 
 ### :rubygems_url
 
-**Default value:** `https://www.rubygems.org`
+**Default value:** `https://rubygems.org`
 
 **Valid values:** A valid gem source URL
 

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -5,12 +5,12 @@ module Gemstash
   #:nodoc:
   class Configuration
     DEFAULTS = {
-      :cache_type => "memory",
-      :base_path => File.expand_path("~/.gemstash"),
-      :db_adapter => "sqlite3",
-      :bind => "tcp://0.0.0.0:9292",
-      :rubygems_url => "https://www.rubygems.org",
-      :protected_fetch => false
+      cache_type: "memory",
+      base_path: File.expand_path("~/.gemstash"),
+      db_adapter: "sqlite3",
+      bind: "tcp://0.0.0.0:9292",
+      rubygems_url: "https://rubygems.org",
+      protected_fetch: false
     }.freeze
 
     DEFAULT_FILE = File.expand_path("~/.gemstash/config.yml").freeze

--- a/spec/gemstash/dependencies_spec.rb
+++ b/spec/gemstash/dependencies_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Gemstash::Dependencies do
-  let(:upstream) { "https://www.rubygems.org" }
+  let(:upstream) { "https://rubygems.org" }
   let(:http_client) { double }
   let(:web_deps) { Gemstash::Dependencies.for_upstream(upstream, http_client) }
   let(:db_deps) { Gemstash::Dependencies.for_private }

--- a/spec/gemstash/gem_source_spec.rb
+++ b/spec/gemstash/gem_source_spec.rb
@@ -83,7 +83,7 @@ describe Gemstash::GemSource do
       }
     end
 
-    let(:upstream_url) { "https://www.rubygems.org" }
+    let(:upstream_url) { "https://rubygems.org" }
     let(:result) { double }
 
     it "sets the source to RubygemsSource" do

--- a/spec/gemstash/upstream_spec.rb
+++ b/spec/gemstash/upstream_spec.rb
@@ -60,32 +60,32 @@ describe Gemstash::Upstream do
   end
 
   describe ".url" do
-    let(:server_url) { "https://www.rubygems.org" }
+    let(:server_url) { "https://rubygems.org" }
     let(:upstream) { Gemstash::Upstream.new(server_url) }
 
     context "with nothing provided" do
       it "returns the server url" do
-        expect(upstream.url).to eq("https://www.rubygems.org")
-        expect(upstream.url(nil, "")).to eq("https://www.rubygems.org")
-        expect(upstream.url("", "")).to eq("https://www.rubygems.org")
+        expect(upstream.url).to eq("https://rubygems.org")
+        expect(upstream.url(nil, "")).to eq("https://rubygems.org")
+        expect(upstream.url("", "")).to eq("https://rubygems.org")
       end
     end
 
     context "with just a query string provided" do
       it "returns the url" do
-        expect(upstream.url(nil, "abc=123")).to eq("https://www.rubygems.org?abc=123")
+        expect(upstream.url(nil, "abc=123")).to eq("https://rubygems.org?abc=123")
       end
     end
 
     context "with just a path provided" do
       it "returns the url" do
-        expect(upstream.url("path/somewhere")).to eq("https://www.rubygems.org/path/somewhere")
+        expect(upstream.url("path/somewhere")).to eq("https://rubygems.org/path/somewhere")
       end
     end
 
     context "with just a path and query string provided" do
       it "returns the url" do
-        expect(upstream.url("path/somewhere", "abc=123")).to eq("https://www.rubygems.org/path/somewhere?abc=123")
+        expect(upstream.url("path/somewhere", "abc=123")).to eq("https://rubygems.org/path/somewhere?abc=123")
       end
     end
   end

--- a/spec/gemstash/web_spec.rb
+++ b/spec/gemstash/web_spec.rb
@@ -32,7 +32,7 @@ describe Gemstash::Web do
     Gemstash::Web.new(http_client_builder: http_client_builder,
                       gemstash_env: test_env)
   end
-  let(:upstream) { "https://www.rubygems.org" }
+  let(:upstream) { "https://rubygems.org" }
   let(:gem_source) { Gemstash::GemSource::RubygemsSource }
 
   let(:rack_env) do
@@ -57,7 +57,7 @@ describe Gemstash::Web do
     it "redirects to rubygems.org" do
       get request, {}, rack_env
 
-      expect(last_response).to redirect_to("https://www.rubygems.org")
+      expect(last_response).to redirect_to("https://rubygems.org")
     end
   end
 


### PR DESCRIPTION
Since `www.rubygems.org` is a 301 to `rubygems.org`, we should not be using that anywhere. This drops the `www` prefix everywhere it is used.