### PR TITLE
Travis: add Gemfile for ruby-head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /html/
 /lib/gemstash/man/
 .*
+gemfiles/Gemfile.ruby-head.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
 - 2.0
 - 2.1
 - 2.2
+- 2.3.2
 - ruby-head
 bundler_args: "--binstubs --jobs=3 --retry=3"
 before_install: gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 matrix:
   allow_failures:
   - rvm: ruby-head
+    gemfile: 'gemfiles/Gemfile.ruby-head'
   include:
   - rvm: jruby-9.0.3.0
     env: JRUBY_OPTS="$JRUBY_OPTS -J-Xmx1536m -J-XX:MaxPermSize=192m"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   - rvm: ruby-head
     gemfile: 'gemfiles/Gemfile.ruby-head'
   include:
-  - rvm: jruby-9.0.3.0
+  - rvm: jruby-9.1.6.0
     env: JRUBY_OPTS="$JRUBY_OPTS -J-Xmx1536m -J-XX:MaxPermSize=192m"
 rvm:
 - 2.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 # Declare Ruby version so that activesupport gem can notice that
-ruby_version RUBY_VERSION
+ruby RUBY_VERSION
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source "https://rubygems.org"
 
+ruby_version RUBY_VERSION
+
 # Specify your gem's dependencies in gemstash.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
+# Declare Ruby version so that activesupport gem can notice that
 ruby_version RUBY_VERSION
 
-# Specify your gem's dependencies in gemstash.gemspec
 gemspec

--- a/gemfiles/Gemfile.ruby-head
+++ b/gemfiles/Gemfile.ruby-head
@@ -1,0 +1,3 @@
+eval_gemfile File.expand_path('../Gemfile', __dir__)
+
+gem 'json', '>= 2.0'

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -28,7 +28,7 @@ you push your own private gems as well."
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  if RUBY_VERSION > "2.3"
+  if RUBY_VERSION > "2.4"
     spec.add_runtime_dependency "activesupport", "~> 5.0"
   else
     spec.add_runtime_dependency "activesupport", "~> 4.2"

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -28,7 +28,7 @@ you push your own private gems as well."
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 4.2"
+  spec.add_runtime_dependency "activesupport", ">= 4.2", "< 6"
   spec.add_runtime_dependency "dalli", "~> 2.7"
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday_middleware", "~> 0.10"

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -28,12 +28,7 @@ you push your own private gems as well."
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  if RUBY_VERSION > "2.4"
-    spec.add_runtime_dependency "activesupport", "~> 5.0"
-  else
-    spec.add_runtime_dependency "activesupport", "~> 4.2"
-  end
-
+  spec.add_runtime_dependency "activesupport", ">= 4.2"
   spec.add_runtime_dependency "dalli", "~> 2.7"
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday_middleware", "~> 0.10"

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -28,7 +28,12 @@ you push your own private gems as well."
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", "~> 4.2"
+  if RUBY_VERSION > "2.3"
+    spec.add_runtime_dependency "activesupport", "~> 5.0"
+  else
+    spec.add_runtime_dependency "activesupport", "~> 4.2"
+  end
+
   spec.add_runtime_dependency "dalli", "~> 2.7"
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday_middleware", "~> 0.10"


### PR DESCRIPTION
This PR tries to make Ruby 2.4.0 build right.

- add a `gemfiles/` folder with a Ruby 2.4.x-specific Gemfile that uses `json` gem in v2.x
- point to it in `.travis.yml`
- git ignore lockfiles in there

