### PR TITLE
Travis: use ruby 2.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
 - 2.0
 - 2.1
 - 2.2
-- 2.3.2
+- 2.3.3
 - ruby-head
 bundler_args: "--binstubs --jobs=3 --retry=3"
 before_install: gem install bundler


### PR DESCRIPTION
This trivial PR bumps the Ruby version from 2.3.2 to 2.3.3.