### PR TITLE
Support the latest_specs endpoint

### DIFF
--- a/lib/gemstash/db/version.rb
+++ b/lib/gemstash/db/version.rb
@@ -30,8 +30,17 @@ module Gemstash
         end
       end
 
-      def self.for_spec_collection(prerelease: false)
-        where(indexed: true, prerelease: prerelease).association_join(:rubygem)
+      def self.for_spec_collection(prerelease: false, latest: false)
+        versions = where(indexed: true, prerelease: prerelease).association_join(:rubygem)
+        latest ? select_latest(versions) : versions
+      end
+
+      def self.select_latest(versions)
+        versions.
+          all.
+          group_by {|version| [version.rubygem_id, version.platform] }.
+          values.
+          map {|gem_versions| gem_versions.max_by {|version| Gem::Version.new(version.number) } }
       end
 
       def self.find_by_spec(gem_id, spec)

--- a/lib/gemstash/gem_source/private_source.rb
+++ b/lib/gemstash/gem_source/private_source.rb
@@ -80,12 +80,13 @@ module Gemstash
         end
       end
 
-      def serve_latest_specs
-        halt 403, "Not yet supported"
-      end
-
       def serve_specs
         params[:prerelease] = false
+        protected(Gemstash::SpecsBuilder)
+      end
+
+      def serve_latest_specs
+        params[:latest] = true
         protected(Gemstash::SpecsBuilder)
       end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -131,6 +131,12 @@ describe "gemstash integration tests" do
           to exit_success.and_output(/speaker \(0.1.0\)/)
       end
 
+      it "finds the latest version of private gems", db_transaction: false do
+        env = { "HOME" => env_dir }
+        expect(execute("gem", ["search", "-r", "speaker", "--clear-sources", "--source", host], env: env)).
+          to exit_success.and_output(/speaker \(0.1.0\)/)
+      end
+
       it "finds private gems when just the private source is configured", db_transaction: false do
         skip "this doesn't work because Rubygems sends /specs.4.8.gz instead of /private/specs.4.8.gz"
         env = { "HOME" => env_dir }


### PR DESCRIPTION
This adds support for the `latest_specs.4.8.gz` endpoint that is required for several gem commands to work properly (e.g. `gem install` and `gem search` without the `-a` flag).  See #129 for more details.

There might be a more efficient way to implement the database query.  I'm not aware of a way to do proper gem version comparisons in the DB, so it seemed to just pull all of the versions and do the latest version selection in Ruby.

If a gem has platform-specific versions, the latest version for each platform will be returned by this code.  That seems to match what the `latest_specs.4.8.gz` endpoint on rubygems.org does.

I added several unit tests and one new integration test that shows the difference in behavior between `gem search -a` and `gem search`.

It might be worth adding integration tests for the `gem install` command, but I wasn't sure what kind of test infrastructure that would require.  I'd be happy to write such a spec if someone can give me a little guidance there.

Fixes #129 