### PR TITLE
Backport latest_specs api for private gems to the 1.0 stable branch

### DIFF
--- a/lib/gemstash/db/version.rb
+++ b/lib/gemstash/db/version.rb
@@ -19,8 +19,17 @@ module Gemstash
         [rubygem.name, Gem::Version.new(number), platform]
       end
 
-      def self.for_spec_collection(prerelease: false)
-        where(indexed: true, prerelease: prerelease).association_join(:rubygem)
+      def self.for_spec_collection(prerelease: false, latest: false)
+        versions = where(indexed: true, prerelease: prerelease).association_join(:rubygem)
+        latest ? select_latest(versions) : versions
+      end
+
+      def self.select_latest(versions)
+        versions.
+          all.
+          group_by {|version| [version.rubygem_id, version.platform] }.
+          values.
+          map {|gem_versions| gem_versions.max_by {|version| Gem::Version.new(version.number) } }
       end
 
       def self.find_by_spec(gem_id, spec)

--- a/lib/gemstash/gem_source/private_source.rb
+++ b/lib/gemstash/gem_source/private_source.rb
@@ -85,13 +85,14 @@ module Gemstash
         gem.content(:gem)
       end
 
-      def serve_latest_specs
-        halt 403, "Not yet supported"
-      end
-
       def serve_specs
         content_type "application/octet-stream"
         Gemstash::SpecsBuilder.all
+      end
+
+      def serve_latest_specs
+        content_type "application/octet-stream"
+        Gemstash::SpecsBuilder.latest
       end
 
       def serve_prerelease_specs

--- a/lib/gemstash/specs_builder.rb
+++ b/lib/gemstash/specs_builder.rb
@@ -20,14 +20,20 @@ module Gemstash
       new(prerelease: true).build
     end
 
+    def self.latest
+      new(latest: true).build
+    end
+
     def self.invalidate_stored
       storage = Gemstash::Storage.for("private").for("specs_collection")
       storage.resource("specs.4.8.gz").delete(:specs)
+      storage.resource("latest_specs.4.8.gz").delete(:specs)
       storage.resource("prerelease_specs.4.8.gz").delete(:specs)
     end
 
-    def initialize(prerelease: false)
+    def initialize(prerelease: false, latest: false)
       @prerelease = prerelease
+      @latest = latest
     end
 
     def build
@@ -47,7 +53,9 @@ module Gemstash
     end
 
     def fetch_resource
-      if @prerelease
+      if @latest
+        storage.resource("latest_specs.4.8.gz")
+      elsif @prerelease
         storage.resource("prerelease_specs.4.8.gz")
       else
         storage.resource("specs.4.8.gz")
@@ -64,7 +72,7 @@ module Gemstash
     end
 
     def fetch_versions
-      @versions = Gemstash::DB::Version.for_spec_collection(prerelease: @prerelease).map(&:to_spec)
+      @versions = Gemstash::DB::Version.for_spec_collection(prerelease: @prerelease, latest: @latest).map(&:to_spec)
     end
 
     def marshal

--- a/spec/gemstash/specs_builder_spec.rb
+++ b/spec/gemstash/specs_builder_spec.rb
@@ -7,6 +7,11 @@ describe Gemstash::SpecsBuilder do
       expect(Marshal.load(gunzip(result))).to eq([])
     end
 
+    it "returns an empty latest result" do
+      result = Gemstash::SpecsBuilder.latest
+      expect(Marshal.load(gunzip(result))).to eq([])
+    end
+
     it "returns an empty prerelease result" do
       result = Gemstash::SpecsBuilder.prerelease
       expect(Marshal.load(gunzip(result))).to eq([])
@@ -17,6 +22,12 @@ describe Gemstash::SpecsBuilder do
     let(:expected_specs) do
       [["example", Gem::Version.new("0.0.1"), "ruby"],
        ["example", Gem::Version.new("0.0.2"), "ruby"],
+       ["example", Gem::Version.new("0.0.2"), "java"],
+       ["other-example", Gem::Version.new("0.1.0"), "ruby"]]
+    end
+
+    let(:expected_latest_specs) do
+      [["example", Gem::Version.new("0.0.2"), "ruby"],
        ["example", Gem::Version.new("0.0.2"), "java"],
        ["other-example", Gem::Version.new("0.1.0"), "ruby"]]
     end
@@ -33,6 +44,11 @@ describe Gemstash::SpecsBuilder do
     it "marshals and gzips the versions" do
       result = Gemstash::SpecsBuilder.all
       expect(Marshal.load(gunzip(result))).to match_array(expected_specs)
+    end
+
+    it "marshals and gzips the latest versions" do
+      result = Gemstash::SpecsBuilder.latest
+      expect(Marshal.load(gunzip(result))).to match_array(expected_latest_specs)
     end
 
     it "returns an empty prerelease result" do
@@ -63,6 +79,11 @@ describe Gemstash::SpecsBuilder do
       expect(Marshal.load(gunzip(result))).to eq([])
     end
 
+    it "returns an empty latest result" do
+      result = Gemstash::SpecsBuilder.latest
+      expect(Marshal.load(gunzip(result))).to eq([])
+    end
+
     it "marshals and gzips the prerelease versions" do
       result = Gemstash::SpecsBuilder.prerelease
       expect(Marshal.load(gunzip(result))).to match_array(expected_prerelease_specs)
@@ -73,6 +94,12 @@ describe Gemstash::SpecsBuilder do
     let(:expected_specs) do
       [["example", Gem::Version.new("0.0.1"), "ruby"],
        ["example", Gem::Version.new("0.0.2"), "ruby"],
+       ["example", Gem::Version.new("0.0.2"), "java"],
+       ["other-example", Gem::Version.new("0.1.0"), "ruby"]]
+    end
+
+    let(:expected_latest_specs) do
+      [["example", Gem::Version.new("0.0.2"), "ruby"],
        ["example", Gem::Version.new("0.0.2"), "java"],
        ["other-example", Gem::Version.new("0.1.0"), "ruby"]]
     end
@@ -102,6 +129,11 @@ describe Gemstash::SpecsBuilder do
       expect(Marshal.load(gunzip(result))).to match_array(expected_specs)
     end
 
+    it "marshals and gzips the latest versions" do
+      result = Gemstash::SpecsBuilder.latest
+      expect(Marshal.load(gunzip(result))).to match_array(expected_latest_specs)
+    end
+
     it "marshals and gzips the prerelease versions" do
       result = Gemstash::SpecsBuilder.prerelease
       expect(Marshal.load(gunzip(result))).to match_array(expected_prerelease_specs)
@@ -112,6 +144,12 @@ describe Gemstash::SpecsBuilder do
     let(:expected_specs) do
       [["example", Gem::Version.new("0.0.1"), "ruby"],
        ["example", Gem::Version.new("0.0.2"), "ruby"],
+       ["example", Gem::Version.new("0.0.2"), "java"],
+       ["other-example", Gem::Version.new("0.1.0"), "ruby"]]
+    end
+
+    let(:expected_latest_specs) do
+      [["example", Gem::Version.new("0.0.2"), "ruby"],
        ["example", Gem::Version.new("0.0.2"), "java"],
        ["other-example", Gem::Version.new("0.1.0"), "ruby"]]
     end
@@ -147,6 +185,11 @@ describe Gemstash::SpecsBuilder do
       expect(Marshal.load(gunzip(result))).to match_array(expected_specs)
     end
 
+    it "marshals and gzips the latest versions" do
+      result = Gemstash::SpecsBuilder.latest
+      expect(Marshal.load(gunzip(result))).to match_array(expected_latest_specs)
+    end
+
     it "marshals and gzips the prerelease versions" do
       result = Gemstash::SpecsBuilder.prerelease
       expect(Marshal.load(gunzip(result))).to match_array(expected_prerelease_specs)
@@ -155,7 +198,8 @@ describe Gemstash::SpecsBuilder do
 
   context "with a new spec pushed" do
     let(:initial_specs) { [["example", Gem::Version.new("0.0.1"), "ruby"]] }
-    let(:specs_after_push) { initial_specs + [["example", Gem::Version.new("0.1.0"), "ruby"]] }
+    let(:new_specs) { [["example", Gem::Version.new("0.1.0"), "ruby"]] }
+    let(:specs_after_push) { initial_specs + new_specs }
 
     before do
       Gemstash::Authorization.authorize("auth-key", "all")
@@ -169,6 +213,14 @@ describe Gemstash::SpecsBuilder do
       Gemstash::GemPusher.new("auth-key", read_gem("example", "0.1.0")).push
       result = Gemstash::SpecsBuilder.all
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_push)
+    end
+
+    it "busts the latest cache" do
+      result = Gemstash::SpecsBuilder.latest
+      expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
+      Gemstash::GemPusher.new("auth-key", read_gem("example", "0.1.0")).push
+      result = Gemstash::SpecsBuilder.latest
+      expect(Marshal.load(gunzip(result))).to match_array(new_specs)
     end
   end
 
@@ -197,6 +249,8 @@ describe Gemstash::SpecsBuilder do
        ["example", Gem::Version.new("0.1.0"), "ruby"]]
     end
 
+    let(:latest_specs) { [["example", Gem::Version.new("0.1.0"), "ruby"]] }
+
     let(:specs_after_yank) { [["example", Gem::Version.new("0.0.1"), "ruby"]] }
 
     before do
@@ -211,6 +265,14 @@ describe Gemstash::SpecsBuilder do
       expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
       Gemstash::GemYanker.new("auth-key", "example", "0.1.0").yank
       result = Gemstash::SpecsBuilder.all
+      expect(Marshal.load(gunzip(result))).to match_array(specs_after_yank)
+    end
+
+    it "busts the latest cache" do
+      result = Gemstash::SpecsBuilder.latest
+      expect(Marshal.load(gunzip(result))).to match_array(latest_specs)
+      Gemstash::GemYanker.new("auth-key", "example", "0.1.0").yank
+      result = Gemstash::SpecsBuilder.latest
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_yank)
     end
   end
@@ -241,7 +303,8 @@ describe Gemstash::SpecsBuilder do
 
   context "with a spec unyanked" do
     let(:initial_specs) { [["example", Gem::Version.new("0.0.1"), "ruby"]] }
-    let(:specs_after_unyank) { initial_specs + [["example", Gem::Version.new("0.1.0"), "ruby"]] }
+    let(:new_specs) { [["example", Gem::Version.new("0.1.0"), "ruby"]] }
+    let(:specs_after_unyank) { initial_specs + new_specs }
 
     before do
       Gemstash::Authorization.authorize("auth-key", "all")
@@ -257,6 +320,14 @@ describe Gemstash::SpecsBuilder do
       Gemstash::GemUnyanker.new("auth-key", "example", "0.1.0").unyank
       result = Gemstash::SpecsBuilder.all
       expect(Marshal.load(gunzip(result))).to match_array(specs_after_unyank)
+    end
+
+    it "busts the latest cache" do
+      result = Gemstash::SpecsBuilder.latest
+      expect(Marshal.load(gunzip(result))).to match_array(initial_specs)
+      Gemstash::GemUnyanker.new("auth-key", "example", "0.1.0").unyank
+      result = Gemstash::SpecsBuilder.latest
+      expect(Marshal.load(gunzip(result))).to match_array(new_specs)
     end
   end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -129,18 +129,18 @@ describe "gemstash integration tests" do
       end
 
       it "finds private gems when just the private source is configured", db_transaction: false do
-        env = { "HOME" => env_dir }
-        expect(execute("gem", ["source", "-r", "https://rubygems.org/"], env: env)).to exit_success
-        expect(execute("gem", ["source", "-a", "#{host}/"], env: env)).to exit_success
-        expect(execute("gem", ["search", "-ar", "speaker"], env: env)).
-          to exit_success.and_output(/speaker \(0.1.0\)/)
-      end
-
-      it "finds private gems when just the private source is configured without a trailing slash", db_transaction: false do
         skip "this doesn't work because Rubygems sends /specs.4.8.gz instead of /private/specs.4.8.gz"
         env = { "HOME" => env_dir }
         expect(execute("gem", ["source", "-r", "https://rubygems.org/"], env: env)).to exit_success
         expect(execute("gem", ["source", "-a", host], env: env)).to exit_success
+        expect(execute("gem", ["search", "-ar", "speaker"], env: env)).
+          to exit_success.and_output(/speaker \(0.1.0\)/)
+      end
+
+      it "finds private gems when just the private source is configured with a trailing slash", db_transaction: false do
+        env = { "HOME" => env_dir }
+        expect(execute("gem", ["source", "-r", "https://rubygems.org/"], env: env)).to exit_success
+        expect(execute("gem", ["source", "-a", "#{host}/"], env: env)).to exit_success
         expect(execute("gem", ["search", "-ar", "speaker"], env: env)).
           to exit_success.and_output(/speaker \(0.1.0\)/)
       end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -69,7 +69,8 @@ describe "gemstash integration tests" do
   end
 
   describe "interacting with private gems" do
-    let(:env_dir) { env_path("integration_spec/private_gems") }
+    let(:env_name) { "integration_spec/private_gems" }
+    let(:env_dir) { env_path(env_name) }
     let(:host) { "#{@gemstash.url}/private" }
     let(:gem_name) { "speaker" }
     let(:gem) { gem_path(gem_name, gem_version) }
@@ -93,6 +94,11 @@ describe "gemstash integration tests" do
       Gemstash::Authorization.authorize("test-key", "all")
     end
 
+    after do
+      # Some actions affect files in the environment, like adding and removing sources
+      clean_env env_name
+    end
+
     context "pushing a gem" do
       before do
         expect(deps.fetch(%w(speaker))).to match_dependencies([])
@@ -106,6 +112,37 @@ describe "gemstash integration tests" do
         expect(deps.fetch(%w(speaker))).to match_dependencies([speaker_deps])
         expect(storage.resource("speaker-0.1.0").content(:gem)).to eq(gem_contents)
         expect(http_client.get("gems/speaker-0.1.0")).to eq(gem_contents)
+      end
+    end
+
+    context "searching for a gem" do
+      before do
+        Gemstash::GemPusher.new(auth, gem_contents).serve
+        expect(deps.fetch(%w(speaker))).to match_dependencies([speaker_deps])
+        @gemstash.env.cache.flush
+      end
+
+      it "finds private gems", db_transaction: false do
+        env = { "HOME" => env_dir }
+        expect(execute("gem", ["search", "-ar", "speaker", "--clear-sources", "--source", host], env: env)).
+          to exit_success.and_output(/speaker \(0.1.0\)/)
+      end
+
+      it "finds private gems when just the private source is configured", db_transaction: false do
+        env = { "HOME" => env_dir }
+        expect(execute("gem", ["source", "-r", "https://rubygems.org/"], env: env)).to exit_success
+        expect(execute("gem", ["source", "-a", "#{host}/"], env: env)).to exit_success
+        expect(execute("gem", ["search", "-ar", "speaker"], env: env)).
+          to exit_success.and_output(/speaker \(0.1.0\)/)
+      end
+
+      it "finds private gems when just the private source is configured without a trailing slash", db_transaction: false do
+        skip "this doesn't work because Rubygems sends /specs.4.8.gz instead of /private/specs.4.8.gz"
+        env = { "HOME" => env_dir }
+        expect(execute("gem", ["source", "-r", "https://rubygems.org/"], env: env)).to exit_success
+        expect(execute("gem", ["source", "-a", host], env: env)).to exit_success
+        expect(execute("gem", ["search", "-ar", "speaker"], env: env)).
+          to exit_success.and_output(/speaker \(0.1.0\)/)
       end
     end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -117,7 +117,7 @@ describe "gemstash integration tests" do
 
     context "searching for a gem" do
       before do
-        Gemstash::GemPusher.new(auth, gem_contents).serve
+        Gemstash::GemPusher.new("test-key", gem_contents).push
         expect(deps.fetch(%w(speaker))).to match_dependencies([speaker_deps])
         @gemstash.env.cache.flush
       end
@@ -125,6 +125,12 @@ describe "gemstash integration tests" do
       it "finds private gems", db_transaction: false do
         env = { "HOME" => env_dir }
         expect(execute("gem", ["search", "-ar", "speaker", "--clear-sources", "--source", host], env: env)).
+          to exit_success.and_output(/speaker \(0.1.0\)/)
+      end
+
+      it "finds the latest version of private gems", db_transaction: false do
+        env = { "HOME" => env_dir }
+        expect(execute("gem", ["search", "-r", "speaker", "--clear-sources", "--source", host], env: env)).
           to exit_success.and_output(/speaker \(0.1.0\)/)
       end
 

--- a/spec/support/exec_helpers.rb
+++ b/spec/support/exec_helpers.rb
@@ -48,7 +48,12 @@ module ExecHelpers
 
     def matches_output?(expected)
       return true unless expected
-      @output == expected
+
+      if expected.is_a?(Regexp)
+        @output =~ expected
+      else
+        @output == expected
+      end
     end
 
   private

--- a/spec/support/exec_helpers.rb
+++ b/spec/support/exec_helpers.rb
@@ -103,7 +103,7 @@ module ExecHelpers
   class JRubyResult < Result
     def exec
       binstub_dir = File.expand_path("../jruby_binstubs", __FILE__)
-      binstub = File.join(binstub_dir, command)
+      binstub = File.join(binstub_dir, File.basename(command))
       raise "Missing binstub for #{command}" unless File.exist?(binstub)
       exec_in_process(binstub)
     end

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -4,14 +4,15 @@ require "zlib"
 
 # Helper methods to easily find and manipulate test files.
 module FileHelpers
-  def gem_path(name, version)
+  def gem_path(name, version, platform: "ruby")
     gems_dir = File.expand_path("../../data/gems", __FILE__)
     gem_dir = File.join(gems_dir, name)
+    version = "#{version}-#{platform}" unless platform == "ruby"
     File.join(gem_dir, "pkg/#{name}-#{version}.gem")
   end
 
-  def read_gem(name, version)
-    File.open(gem_path(name, version), "rb", &:read)
+  def read_gem(name, version, platform: "ruby")
+    File.open(gem_path(name, version, platform: platform), "rb", &:read)
   end
 
   def env_path(name)

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -19,6 +19,11 @@ module FileHelpers
     File.join(envs_dir, name)
   end
 
+  def clean_env(name)
+    dir = env_path(name)
+    expect(execute("git", ["clean", "-fdx", dir])).to exit_success
+  end
+
   def bundle_path(name)
     bundles_dir = File.expand_path("../../data/bundles", __FILE__)
     File.join(bundles_dir, name)

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -21,7 +21,7 @@ module FileHelpers
 
   def clean_env(name)
     dir = env_path(name)
-    expect(execute("git", ["clean", "-fdx", dir])).to exit_success
+    expect(execute("git", ["clean", "-fdx", dir], env: { "PATH" => ENV["PATH"] })).to exit_success
   end
 
   def bundle_path(name)

--- a/spec/support/jruby_binstubs/git
+++ b/spec/support/jruby_binstubs/git
@@ -1,0 +1,11 @@
+def which(executable)
+  ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
+    exe_path = File.join(path, executable)
+    return exe_path if File.file?(exe_path) && File.executable?(exe_path)
+  end
+
+  nil
+end
+
+system which("git"), *ARGV
+exit $?.exitstatus

--- a/spec/support/jruby_binstubs/speaker
+++ b/spec/support/jruby_binstubs/speaker
@@ -1,0 +1,1 @@
+load Gem.bin_path("speaker", "speaker")

--- a/spec/support/simple_server.rb
+++ b/spec/support/simple_server.rb
@@ -148,7 +148,12 @@ class SimpleServer
     # rubocop:disable Style/MethodName
     def do_GET(request, response)
       # rubocop:enable Style/MethodName
-      @simple_server.routes[request.path].call request, response
+      if @simple_server.routes.include?(request.path)
+        @simple_server.routes[request.path].call request, response
+      else
+        STDERR.puts "[SimpleServer] no route found: #{request.path}"
+        raise WEBrick::HTTPStatus::NotFound
+      end
     end
   end
 end


### PR DESCRIPTION
I also pulled in #113 as it was used by #131, and it is just adding some more tests, so should be fine to pull in to the 1.0 branch.