### PR TITLE
Prepare for next 1.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   allow_failures:
   - rvm: ruby-head
   include:
-  - rvm: jruby-9.0.3.0
+  - rvm: jruby-9.1.7.0
     env: JRUBY_OPTS="$JRUBY_OPTS -J-Xmx1536m -J-XX:MaxPermSize=192m"
 rvm:
 - 2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   allow_failures:
   - rvm: ruby-head
   include:
-  - rvm: jruby-9.1.7.0
+  - rvm: jruby-9.1.6.0
     env: JRUBY_OPTS="$JRUBY_OPTS -J-Xmx1536m -J-XX:MaxPermSize=192m"
 rvm:
 - 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - Fix broken JRuby build ([#91](https://github.com/bundler/gemstash/pull/91), [@smellsblue](https://github.com/smellsblue))
   - Drop www.rubygems.org in favor of rubygems.org ([#101](https://github.com/bundler/gemstash/pull/101), [@smellsblue](https://github.com/smellsblue))
   - Redirect /versions and /info/* to index.rubygems.org ([#102](https://github.com/bundler/gemstash/pull/102), [@smellsblue](https://github.com/smellsblue))
+  - Backports to the 1.0 branch ([#103](https://github.com/bundler/gemstash/pull/103), [@smellsblue](https://github.com/smellsblue))
 
 ## 1.0.1 (2016-02-23)
 
@@ -79,3 +80,27 @@
   - Push, yank, and unyank private gems
   - Zero setup dependencies
   - Optionally use Memcached for caching or PostgreSQL for the database
+  - Pull strategies and storage from bundler-api ([#5](https://github.com/bundler/gemstash/pull/5), [@pcarranza](https://github.com/pcarranza))
+  - Defer db connection test until sqlite db file exists ([#8](https://github.com/bundler/gemstash/pull/8), [@carpodaster](https://github.com/carpodaster))
+  - Integration specs ([#9](https://github.com/bundler/gemstash/pull/9), [@smellsblue](https://github.com/smellsblue))
+  - Logging all the things to a file ([#10](https://github.com/bundler/gemstash/pull/10), [@pcarranza](https://github.com/pcarranza))
+  - Gem sources ([#11](https://github.com/bundler/gemstash/pull/11), [@smellsblue](https://github.com/smellsblue))
+  - Forward http user agent to the upstream server ([#23](https://github.com/bundler/gemstash/pull/23), [@pcarranza](https://github.com/pcarranza))
+  - Documentation ([#25](https://github.com/bundler/gemstash/pull/25), [@smellsblue](https://github.com/smellsblue), [@pcarranza](https://github.com/pcarranza))
+  - Avoid filesystem limits using a trie ([#26](https://github.com/bundler/gemstash/pull/26), [@smellsblue](https://github.com/smellsblue))
+  - A few tweaks: enable setting the host to bind to, and reduced access for some attributes ([#28](https://github.com/bundler/gemstash/pull/28), [@pcarranza](https://github.com/pcarranza))
+  - Handle upstream connection error correctly and die with dignity ([#29](https://github.com/bundler/gemstash/pull/29), [@pcarranza](https://github.com/pcarranza))
+  - Add many ruby versions to travis configuration ([#31](https://github.com/bundler/gemstash/pull/31), [@pcarranza](https://github.com/pcarranza))
+  - Add rubygems version enforcement ([#32](https://github.com/bundler/gemstash/pull/32), [@pcarranza](https://github.com/pcarranza))
+  - Older RubyGems and Ruby 2.0.0 ([#33](https://github.com/bundler/gemstash/pull/33), [@smellsblue](https://github.com/smellsblue))
+  - Various fixes ([#34](https://github.com/bundler/gemstash/pull/34), [@smellsblue](https://github.com/smellsblue))
+  - Yanking gems ([#36](https://github.com/bundler/gemstash/pull/36), [@smellsblue](https://github.com/smellsblue))
+  - Use Sequel::Model ([#37](https://github.com/bundler/gemstash/pull/37), [@smellsblue](https://github.com/smellsblue))
+  - Build against JRuby ([#38](https://github.com/bundler/gemstash/pull/38), [@smellsblue](https://github.com/smellsblue))
+  - Unyanking gems ([#39](https://github.com/bundler/gemstash/pull/39), [@smellsblue](https://github.com/smellsblue))
+  - Add status command ([#40](https://github.com/bundler/gemstash/pull/40), [@smellsblue](https://github.com/smellsblue))
+  - Cache if gem is indexed in Gemstash::Storage ([#44](https://github.com/bundler/gemstash/pull/44), [@smellsblue](https://github.com/smellsblue))
+  - Full index bundling ([#45](https://github.com/bundler/gemstash/pull/45), [@smellsblue](https://github.com/smellsblue))
+  - Various fixes 2 ([#47](https://github.com/bundler/gemstash/pull/47), [@smellsblue](https://github.com/smellsblue))
+  - Various fixes 3 ([#49](https://github.com/bundler/gemstash/pull/49), [@smellsblue](https://github.com/smellsblue))
+  - Add Gemtash logo ([#50](https://github.com/bundler/gemstash/pull/50), [@jonathanrieta](https://github.com/jonathanrieta))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.4 (2017-01-27)
+
+### Features
+
+  - Backport `latest_specs.4.8.gz` endpoint for private gems to the 1.0 branch ([#134](https://github.com/bundler/gemstash/pull/134), [@randycoulman](https://github.com/randycoulman), [@smellsblue](https://github.com/smellsblue))
+  - Improve CHANGELOG generation and prepare for `1.0.4` release ([#135](https://github.com/bundler/gemstash/pull/135), [@smellsblue](https://github.com/smellsblue))
+
 ## 1.0.3 (2016-10-15)
 
 ### Bugfixes

--- a/lib/gemstash/version.rb
+++ b/lib/gemstash/version.rb
@@ -1,4 +1,4 @@
 #:nodoc:
 module Gemstash
-  VERSION = "1.0.3".freeze
+  VERSION = "1.0.4".freeze
 end

--- a/rake/changelog.rb
+++ b/rake/changelog.rb
@@ -1,3 +1,5 @@
+require "forwardable"
+require "open3"
 require "set"
 
 # Helper class for updating CHANGELOG.md
@@ -71,28 +73,7 @@ class Changelog
   end
 
   def fetch_missing_pull_requests
-    @missing_pull_requests = missing_pull_request_numbers.map {|pr| fetch_pull_request(pr) }
-  end
-
-  def fetch_pull_request(number)
-    puts "Fetching pull request ##{number}"
-    octokit.pull_request("bundler/gemstash", number)
-  end
-
-  def missing_pull_request_numbers
-    @missing_pull_request_numbers ||= begin
-      commits = `git log --oneline HEAD ^v#{last_version} --grep "^Merge pull request"`.split("\n")
-      pull_requests = commits.map {|commit| commit[/Merge pull request #(\d+)/, 1].to_i }
-      documented = Set.new
-
-      if parsed_current_version
-        parsed_current_version.pull_requests.each do |pr|
-          documented << pr.number.to_i
-        end
-      end
-
-      pull_requests.sort.reject {|pr| documented.include?(pr) }
-    end
+    @missing_pull_requests = MissingPullRequestFetcher.new(self).fetch
   end
 
   def update_changelog
@@ -140,9 +121,7 @@ class Changelog
   end
 
   def section_for(pull_request)
-    puts "Fetching issue for ##{pull_request.number}"
-    issue = pull_request.rels[:issue].get.data
-    labels = issue.labels.map(&:name)
+    labels = pull_request.issue.labels.map(&:name)
 
     if labels.include?("bug")
       "Bugfixes"
@@ -155,9 +134,7 @@ class Changelog
 
   def write_pull_requests(file, pull_requests)
     pull_requests.each do |pr|
-      puts "Fetching commits for ##{pr.number}"
-      commits = pr.rels[:commits].get.data
-      authors = commits.map {|commit| author_link(commit) }.uniq
+      authors = pr.commits.map {|commit| author_link(commit) }.uniq
       file.puts "  - #{pr.title} ([##{pr.number}](#{pr.html_url}), #{authors.join(", ")})"
     end
   end
@@ -191,6 +168,74 @@ class Changelog
       end
 
       Gemstash::VERSION
+    end
+  end
+
+  class PullRequest
+    extend Forwardable
+    def_delegators :@pull_request, :title, :number, :html_url
+
+    def initialize(pull_request)
+      @pull_request = pull_request
+    end
+
+    def commits
+      @commits ||= begin
+        puts "Fetching commits for ##{number}"
+        @pull_request.rels[:commits].get.data
+      end
+    end
+
+    def issue
+      @issue ||= begin
+        puts "Fetching issue for ##{number}"
+        @pull_request.rels[:issue].get.data
+      end
+    end
+  end
+
+  class MissingPullRequestFetcher
+    extend Forwardable
+    def_delegators :@changelog, :octokit, :parsed
+    attr_reader :pull_requests
+
+    def initialize(changelog)
+      @changelog = changelog
+    end
+
+    def fetch
+      fetch_all_pull_requests
+      reject_documented_pull_requests
+      reject_pull_requests_not_in_this_branch
+      pull_requests
+    end
+
+    private
+
+    def fetch_all_pull_requests
+      puts "Fetching all pull requests"
+      @pull_requests = octokit.pull_requests("bundler/gemstash", state: "all").sort_by(&:number).map {|pr| PullRequest.new(pr) }
+    end
+
+    def reject_documented_pull_requests
+      documented_prs = Set.new
+
+      parsed.versions.each do |version|
+        version.pull_requests.each do |pr|
+          documented_prs << pr.number.to_i
+        end
+      end
+
+      pull_requests.reject! {|pr| documented_prs.include?(pr.number) }
+    end
+
+    def reject_pull_requests_not_in_this_branch
+      pull_requests.select! do |pr|
+        pr.commits.all? do |commit|
+          _, status = Open3.capture2e("git rev-list HEAD | grep '#{commit.sha}'")
+          status.success?
+        end
+      end
     end
   end
 end

--- a/rake/changelog.rb
+++ b/rake/changelog.rb
@@ -171,6 +171,8 @@ class Changelog
     end
   end
 
+  # Wraps a pull request instance from octokit so we can expose obtaining the
+  # commits and issue with a single method call.
   class PullRequest
     extend Forwardable
     def_delegators :@pull_request, :title, :number, :html_url
@@ -194,6 +196,8 @@ class Changelog
     end
   end
 
+  # Helper class to fetch the pull requests that are missing from the CHANGELOG
+  # for this branch.
   class MissingPullRequestFetcher
     extend Forwardable
     def_delegators :@changelog, :octokit, :parsed
@@ -210,11 +214,12 @@ class Changelog
       pull_requests
     end
 
-    private
+  private
 
     def fetch_all_pull_requests
       puts "Fetching all pull requests"
-      @pull_requests = octokit.pull_requests("bundler/gemstash", state: "all").sort_by(&:number).map {|pr| PullRequest.new(pr) }
+      @pull_requests = octokit.pull_requests("bundler/gemstash", state: "all").
+        sort_by(&:number).map {|pr| PullRequest.new(pr) }
     end
 
     def reject_documented_pull_requests


### PR DESCRIPTION
* Update `CHANGELOG.md`
* Update `rake changelog` to use GitHub API more, so we can use bundler bot without missing PRs from this task
* Update version number
* Update travis build for JRuby (but not to `9.1.7.0` yet because we are hitting this issue when bundling: https://github.com/sickill/rainbow/issues/48)