### PR TITLE
Travis: Use JRuby 9.1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - rvm: 2.4.0
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.8.0
       env: JRUBY_OPTS="$JRUBY_OPTS -J-Xmx1536m -J-XX:MaxPermSize=192m"
 
 bundler_args: "--binstubs --jobs=3 --retry=3"


### PR DESCRIPTION
This PR updates CI to run against latest stable release of JRuby.