### PR TITLE
Travis: 2.4.1, 2.3.4, jruby-9.1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ matrix:
     - rvm: 2.0
     - rvm: 2.1
     - rvm: 2.2
-    - rvm: 2.3.3
-    - rvm: 2.4.0
+    - rvm: 2.3.4
+    - rvm: 2.4.1
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.8.0
       env: JRUBY_OPTS="$JRUBY_OPTS -J-Xmx1536m -J-XX:MaxPermSize=192m"
 
 bundler_args: "--binstubs --jobs=3 --retry=3"


### PR DESCRIPTION
This PR keeps the versions of new rubies updated.