### PR TITLE
Rake: Turn rake task files into .rake files, auto-loaded

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,6 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
-require_relative "rake/changelog.rb"
-require_relative "rake/doc.rb"
 
 RuboCop::RakeTask.new
 

--- a/rakelib/changelog.rake
+++ b/rakelib/changelog.rake
@@ -48,7 +48,7 @@ class Changelog
 
   def parse_changelog
     require "citrus"
-    Citrus.load(File.expand_path("../changelog.citrus", __FILE__))
+    Citrus.load(File.expand_path("../../rake/changelog.citrus", __FILE__))
     @parsed = Changelog::Grammar.parse(File.read(changelog_file))
     @parsed_current_version = @parsed.versions.find {|version| version.number == current_version }
 

--- a/rakelib/doc.rake
+++ b/rakelib/doc.rake
@@ -88,7 +88,7 @@ class Doc
          upcase_headers.rb
          fix_links_for_format.rb
          fix_github_line_breaks.rb).map do |filter|
-        ::File.expand_path("../doc/#{filter}", __FILE__)
+        ::File.expand_path("../../rake/doc/#{filter}", __FILE__)
       end
     end
 


### PR DESCRIPTION
This PR uses a feature in Rake, which is "any .rake file in `rakelib/` will be auto-required by the Rakefile".

  - call the individual files `.rake`
  - put them in `rakelib/`
  - rename paths to supporting files (which now reside, a little incongruously in `rake/`)

## Question

- [ ] What are good places to place the citrus grammar and the Pandoc filter Ruby programs?
