### PR TITLE
Travis: JRUBY_OPTS w/o invalid option jruby.cext.enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
     - rvm: jruby-9.1.12.0
-      env: JRUBY_OPTS="$JRUBY_OPTS -J-Xmx1536m -J-XX:MaxPermSize=192m"
+      env: JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m -J-XX:MaxPermSize=192m"
 
 bundler_args: "--binstubs --jobs=3 --retry=3"
 


### PR DESCRIPTION
The JRuby test output is cluttered with many instances of this warning:

```
jruby: warning: unknown property jruby.cext.enabled
```

This PR configures `JRUBY_OPTS` to the settings that the Travis image uses, _except_ `jruby.cext.enabled`, which, if set, produces that warning.

**Result**: Same output as an MRI test suite runs. No instances of that warning. 🎉  🎆  🎈 🦊 

  - See https://github.com/travis-ci/travis-ci/issues/6471