### PR TITLE
Suppress deprecation warnings in production code

### DIFF
--- a/lib/gemstash/storage.rb
+++ b/lib/gemstash/storage.rb
@@ -117,6 +117,7 @@ module Gemstash
       digest = Digest::MD5.hexdigest(@name)
       child_folder = "#{safe_name}-#{digest}"
       @folder = File.join(@base_path, *trie_parents, child_folder)
+      @properties = nil
     end
 
     # When +key+ is nil, this will test if this resource exists with any

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -11,7 +11,7 @@ module Gemstash
     def_delegators :@uri, :scheme, :host, :user, :password, :to_s
 
     def initialize(upstream, user_agent: nil)
-      @uri = URI(URI.decode(upstream.to_s))
+      @uri = URI(CGI.unescape(upstream.to_s))
       @user_agent = user_agent
       raise "URL '#{@uri}' is not valid!" unless @uri.to_s =~ URI.regexp
     end

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -13,7 +13,7 @@ module Gemstash
     def initialize(upstream, user_agent: nil)
       @uri = URI(CGI.unescape(upstream.to_s))
       @user_agent = user_agent
-      raise "URL '#{@uri}' is not valid!" unless @uri.to_s =~ URI.regexp
+      raise "URL '#{@uri}' is not valid!" unless @uri.to_s =~ URI::DEFAULT_PARSER.make_regexp
     end
 
     def url(path = nil, params = nil)


### PR DESCRIPTION
This PR suppresses the following Ruby warnings in production codes.

- ⚠️ `warning: URI.unescape is obsolete`
- ⚠️ `warning: URI.regexp is obsolete`
- ⚠️ `warning: instance variable @properties not initialized`
