### PR TITLE
Travis: jruby-9.1.13.0; use dist: "trusty"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: false
-dist: precise
+dist: trusty
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - rvm: 2.4.1
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.13.0
       env: JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m -J-XX:MaxPermSize=192m"
 
 bundler_args: "--binstubs --jobs=3 --retry=3"


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html

Update: In order to pass tests, I updated the `dist` (what kind of machine tests run on in Travis) to `trusty`.