### PR TITLE
Allow puma_workers configuration

### DIFF
--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -14,7 +14,8 @@ module Gemstash
       fetch_timeout: 20,
       # Actual default for db_connection_options is dynamic based on the adapter
       db_connection_options: {},
-      puma_threads: 16
+      puma_threads: 16,
+      puma_workers: 1
     }.freeze
 
     DEFAULT_FILE = File.expand_path("~/.gemstash/config.yml").freeze
@@ -59,7 +60,7 @@ module Gemstash
       when "sqlite3"
         { max_connections: 1 }.merge(self[:db_connection_options])
       when "postgres", "mysql", "mysql2"
-        { max_connections: self[:puma_threads] + 1 }.merge(self[:db_connection_options])
+        { max_connections: (self[:puma_workers] * self[:puma_threads]) + 1 }.merge(self[:db_connection_options])
       else
         raise "Unsupported DB adapter: '#{self[:db_adapter]}'"
       end

--- a/lib/gemstash/puma.rb
+++ b/lib/gemstash/puma.rb
@@ -2,5 +2,5 @@ require "gemstash"
 
 threads 0, Gemstash::Env.current.config[:puma_threads].to_i
 bind Gemstash::Env.current.config[:bind].to_s
-workers 1
+workers Gemstash::Env.current.config[:puma_workers].to_i
 rackup Gemstash::Env.current.rackup


### PR DESCRIPTION
Now you are able to change the number of puma workers.
This also changes the max_connections when using postgres.

### Question

- How do I update the docs? I generated them locally, but couldn't figure out what files feed the doc generation process.