### PR TITLE
Travis: Avoid jruby warning about MaxPermSize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
     - rvm: jruby-9.1.13.0
-      env: JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m -J-XX:MaxPermSize=192m"
+      env: JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m"
 
 bundler_args: "--binstubs --jobs=3 --retry=3"
 


### PR DESCRIPTION
This PR tries to avoid a warning in JRuby build output.

<details>

```
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=192m; support was removed in 8.0
```

<summary>Warning output</summary>

</details>