### PR TITLE
Travis: use JRuby, 9.1.17.0 avoid double gem update --system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - rvm: 2.4.1
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.1.17.0
       env: JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m"
 
 bundler_args: "--binstubs --jobs=3 --retry=3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
     - rvm: 2.0
     - rvm: 2.1
     - rvm: 2.2
-    - rvm: 2.3.4
-    - rvm: 2.4.1
+    - rvm: 2.3.5
+    - rvm: 2.4.2
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
     - rvm: jruby-9.1.13.0
@@ -19,7 +19,6 @@ matrix:
 bundler_args: "--binstubs --jobs=3 --retry=3"
 
 before_install:
-  - gem update --system
   - gem install bundler
 
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - rvm: 2.4.1
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.1.15.0
       env: JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m"
 
 bundler_args: "--binstubs --jobs=3 --retry=3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     - rvm: 2.0
     - rvm: 2.1
     - rvm: 2.2
-    - rvm: 2.3.5
-    - rvm: 2.4.2
+    - rvm: 2.3.4
+    - rvm: 2.4.1
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.14.0
       env: JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m"
 
 bundler_args: "--binstubs --jobs=3 --retry=3"


### PR DESCRIPTION
This PR updates the CI matrix Ruby versions, and avoids a step which `rvm` does now on its own.