### PR TITLE
Travis: jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - rvm: 2.5.1
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
-    - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.0.0
       env: JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m"
 
 bundler_args: "--binstubs --jobs=3 --retry=3"


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/05/24/jruby-9-2-0-0.html