### PR TITLE
do not set puma worker config when running jruby

### DIFF
--- a/lib/gemstash/puma.rb
+++ b/lib/gemstash/puma.rb
@@ -2,5 +2,5 @@ require "gemstash"
 
 threads 0, Gemstash::Env.current.config[:puma_threads].to_i
 bind Gemstash::Env.current.config[:bind].to_s
-workers Gemstash::Env.current.config[:puma_workers].to_i unless RUBY_PLATFORM == 'java'
+workers Gemstash::Env.current.config[:puma_workers].to_i unless RUBY_PLATFORM == "java"
 rackup Gemstash::Env.current.rackup

--- a/lib/gemstash/puma.rb
+++ b/lib/gemstash/puma.rb
@@ -2,5 +2,5 @@ require "gemstash"
 
 threads 0, Gemstash::Env.current.config[:puma_threads].to_i
 bind Gemstash::Env.current.config[:bind].to_s
-workers Gemstash::Env.current.config[:puma_workers].to_i
+workers Gemstash::Env.current.config[:puma_workers].to_i unless RUBY_PLATFORM == 'java'
 rackup Gemstash::Env.current.rackup


### PR DESCRIPTION
puma doesn't like if the worker config is set on jruby and won't even start