### PR TITLE
Fix #188 – Prevent overriding published gems

### DIFF
--- a/lib/gemstash/gem_pusher.rb
+++ b/lib/gemstash/gem_pusher.rb
@@ -28,9 +28,9 @@ module Gemstash
 
     def serve
       check_auth
+      save_to_database
       store_gem
       store_gemspec
-      save_to_database
       invalidate_cache
     end
 

--- a/lib/gemstash/web.rb
+++ b/lib/gemstash/web.rb
@@ -1,7 +1,6 @@
 require "sinatra/base"
 require "json"
 require "gemstash"
-require "pry"
 module Gemstash
   #:nodoc:
   class Web < Sinatra::Base

--- a/lib/gemstash/web.rb
+++ b/lib/gemstash/web.rb
@@ -1,6 +1,7 @@
 require "sinatra/base"
 require "json"
 require "gemstash"
+
 module Gemstash
   #:nodoc:
   class Web < Sinatra::Base

--- a/lib/gemstash/web.rb
+++ b/lib/gemstash/web.rb
@@ -1,7 +1,7 @@
 require "sinatra/base"
 require "json"
 require "gemstash"
-
+require "pry"
 module Gemstash
   #:nodoc:
   class Web < Sinatra::Base
@@ -24,6 +24,11 @@ module Gemstash
     not_found do
       status 404
       body JSON.dump("error" => "Not found", "code" => 404)
+    end
+
+    error GemPusher::ExistingVersionError do
+      status 422
+      body JSON.dump("error" => "Version already exists", "code" => 422)
     end
 
     get "/" do

--- a/spec/gemstash/gem_pusher_spec.rb
+++ b/spec/gemstash/gem_pusher_spec.rb
@@ -154,15 +154,18 @@ describe Gemstash::GemPusher do
     end
 
     context "with an existing version" do
+      let(:serve) { Gemstash::GemPusher.new(auth, gem_contents).serve }
+
       before do
         gem_id = insert_rubygem "example"
         insert_version gem_id, "0.1.0"
         storage.resource("example-0.1.0").save({ gem: "zapatito" }, indexed: true)
       end
 
-      it "rejects the push" do
-        expect { Gemstash::GemPusher.new(auth, gem_contents).serve }.
-          to raise_error(Gemstash::GemPusher::ExistingVersionError)
+      it "rejects the push and does not change the file content" do
+        expect do
+          expect { serve }.to raise_error(Gemstash::GemPusher::ExistingVersionError)
+        end.to_not change { storage.resource("example-0.1.0").content(:gem) }.from("zapatito")
       end
     end
   end

--- a/spec/gemstash/web_spec.rb
+++ b/spec/gemstash/web_spec.rb
@@ -424,7 +424,7 @@ describe Gemstash::Web do
       expect(last_response.status).to eq(200)
     end
 
-    it "returns a 422 when gem already exists" do
+    it "returns a 422 when the gem already exists" do
       post "/api/v1/gems", read_gem("example", "0.1.0"), env
       expect(last_response).to be_ok
 


### PR DESCRIPTION
This PR attempts to fix issue #188 (and the relevant parts of #99).
It does so by re-ordering the storage sequence in the `gem_pusher.rb` file.
Since the database should be the source of truth, checking it first ensures we raise an exception before any on disk side-effects occur.

Longer term, I think it makes sense to use a different storage path on disk (UUID's?) and perhaps even store the checksum in the database. this would allow ensuring the files have not been tampered with.

I also decided to take a stab at part of #99 and ensure that the exception raised is caught and properly handled by the controller.
I opted for 422 as the error code.