### PR TITLE
Fix jruby builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,18 @@ matrix:
     - rvm: 2.5.1
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
-    - rvm: jruby-9.2.0.0
-      env: JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m"
+
+    - language: generic
+      env:
+        - JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m"
+        - JRUBY_VERSION="jruby-9.2.0.0"
+      before_install:
+        - ./ci/build/rvm_setup.sh
+        - rm -f ${HOME}/.rvm/gemsets/jruby/global.gems
+        - rvm use ${JRUBY_VERSION} --install --binary --fuzzy
+        - gem install bundler
+      install: bundle install --binstubs --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+      script: bundle exec rake
 
 bundler_args: "--binstubs --jobs=3 --retry=3"
 

--- a/ci/build/rvm_setup.sh
+++ b/ci/build/rvm_setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Install rvm
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+\curl -sSL https://get.rvm.io | bash -s stable
+
+# for auto reload with msg.
+echo "rvm_auto_reload_flag=1" >> ~/.rvmrc


### PR DESCRIPTION
Install jruby manually in a generic language image, since we can't modify the `/home/travis/.rvm/gemsets/jruby/global.gems` in what travis gives us.

travis `home/travis/.rvm/gemsets/jruby/global.gems`  has in it `jruby-openssl` wich makes rvm install a new version of `jruby-openssl` whenever we install jruby, making the test suite run with that `jruby-openssl` version instead of the one that comes with jruby itself an break.
