### PR TITLE
GEMSTASH-194 Support for FIPS Mode

### DIFF
--- a/lib/gemstash/storage.rb
+++ b/lib/gemstash/storage.rb
@@ -114,7 +114,7 @@ module Gemstash
       trie_parents = safe_name[0...3].downcase.split("")
       # The digest is included in case the name differs only by case
       # Some file systems are case insensitive, so such collisions will be a problem
-      digest = Digest::MD5.hexdigest(@name)
+      digest = Digest::SHA256.hexdigest(@name)
       child_folder = "#{safe_name}-#{digest}"
       @folder = File.join(@base_path, *trie_parents, child_folder)
       @properties = nil

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -40,7 +40,7 @@ module Gemstash
   private
 
     def hash
-      Digest::MD5.hexdigest(to_s)
+      Digest::SHA256.hexdigest(to_s)
     end
 
     #:nodoc:


### PR DESCRIPTION
This updates the digest usage from MD5 to SHA256 to support hosts that are
configured in FIPS mode.

Fixes #194 