### PR TITLE
CI matrix: Drop 2.0, 2.1, 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ matrix:
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
   include:
-    - rvm: 2.0
-    - rvm: 2.1
-    - rvm: 2.2
     - rvm: 2.3.4
     - rvm: 2.4.1
     - rvm: 2.5.1


### PR DESCRIPTION
This PR continues the conversation in #198 - dropping older items from the matrix.