### PR TITLE
Avoid Rubocop warnings

### DIFF
--- a/spec/support/simple_server.rb
+++ b/spec/support/simple_server.rb
@@ -151,7 +151,7 @@ class SimpleServer
       super
     end
 
-    def do_GET(request, response) # rubocop:disable Style/MethodName
+    def do_GET(request, response) # rubocop:disable Naming/MethodName
       if @simple_server.routes.include?(request.path)
         @simple_server.routes[request.path].call request, response
       else

--- a/spec/support/slow_simple_server.rb
+++ b/spec/support/slow_simple_server.rb
@@ -17,7 +17,7 @@ class SlowSimpleServer < SimpleServer
       super
     end
 
-    def do_GET(request, response) # rubocop:disable Style/MethodName
+    def do_GET(request, response) # rubocop:disable Naming/MethodName
       sleep(0.3)
       @simple_server.routes[request.path].call request, response
     end


### PR DESCRIPTION
This PR avoids the warnings output from Rubocop

```
..................................spec/support/simple_server.rb: Style/MethodName has the wrong namespace - should be Naming
..spec/support/slow_simple_server.rb: Style/MethodName has the wrong namespace - should be Naming
.................................................................```