### PR TITLE
RSpec: config.disable_monkey_patching!

### DIFF
--- a/spec/concurrency_spec.rb
+++ b/spec/concurrency_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "gemstash concurrency tests" do
+RSpec.describe "gemstash concurrency tests" do
   let(:timeout) { 5 }
 
   def write_thread(resource_id, content = "unchanging")

--- a/spec/gemstash/authorization_spec.rb
+++ b/spec/gemstash/authorization_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Gemstash::Authorization do
+RSpec.describe Gemstash::Authorization do
   describe "#remove" do
     context "with an existing authoriation" do
       before do

--- a/spec/gemstash/cli/authorize_spec.rb
+++ b/spec/gemstash/cli/authorize_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 require "securerandom"
 require "yaml"
 
-describe Gemstash::CLI::Authorize do
+RSpec.describe Gemstash::CLI::Authorize do
   before do
     # Don't let the environment change, else we get a separate test db
     # connection, which messes up the tests

--- a/spec/gemstash/cli/base_spec.rb
+++ b/spec/gemstash/cli/base_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Gemstash::CLI::Base do
+RSpec.describe Gemstash::CLI::Base do
   let(:cli) do
     result = double(say: nil)
     allow(result).to receive(:set_color) {|x| x }

--- a/spec/gemstash/cli/setup_spec.rb
+++ b/spec/gemstash/cli/setup_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "yaml"
 
-describe Gemstash::CLI::Setup do
+RSpec.describe Gemstash::CLI::Setup do
   let(:cli) do
     result = double(options: cli_options, say: nil)
     allow(result).to receive(:set_color) {|x| x }

--- a/spec/gemstash/configuration_spec.rb
+++ b/spec/gemstash/configuration_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Gemstash::Configuration do
+RSpec.describe Gemstash::Configuration do
   let(:config_dir) { config_path("configuration_spec") }
 
   context "no config file" do

--- a/spec/gemstash/dependencies_spec.rb
+++ b/spec/gemstash/dependencies_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Gemstash::Dependencies do
+RSpec.describe Gemstash::Dependencies do
   let(:upstream) { "https://rubygems.org" }
   let(:http_client) { double }
   let(:web_deps) { Gemstash::Dependencies.for_upstream(upstream, http_client) }

--- a/spec/gemstash/env_spec.rb
+++ b/spec/gemstash/env_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Gemstash::Env do
+RSpec.describe Gemstash::Env do
   context ".log_file" do
     let(:dir) { __dir__ }
 

--- a/spec/gemstash/gem_pusher_spec.rb
+++ b/spec/gemstash/gem_pusher_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "zlib"
 
-describe Gemstash::GemPusher do
+RSpec.describe Gemstash::GemPusher do
   let(:auth) { Gemstash::ApiKeyAuthorization.new(auth_key) }
   let(:auth_with_invalid_auth_key) { Gemstash::ApiKeyAuthorization.new(invalid_auth_key) }
   let(:auth_without_permission) { Gemstash::ApiKeyAuthorization.new(auth_key_without_permission) }

--- a/spec/gemstash/gem_source_spec.rb
+++ b/spec/gemstash/gem_source_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "cgi"
 
-describe Gemstash::GemSource do
+RSpec.describe Gemstash::GemSource do
   let(:app) { double }
   let(:middleware) { Gemstash::GemSource::RackMiddleware.new(app) }
 

--- a/spec/gemstash/gem_yanker_spec.rb
+++ b/spec/gemstash/gem_yanker_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Gemstash::GemYanker do
+RSpec.describe Gemstash::GemYanker do
   let(:auth) { Gemstash::ApiKeyAuthorization.new(auth_key) }
   let(:auth_with_invalid_auth_key) { Gemstash::ApiKeyAuthorization.new(invalid_auth_key) }
   let(:auth_without_permission) { Gemstash::ApiKeyAuthorization.new(auth_key_without_permission) }

--- a/spec/gemstash/http_client_spec.rb
+++ b/spec/gemstash/http_client_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Gemstash::HTTPClient do
+RSpec.describe Gemstash::HTTPClient do
   before(:all) do
     @server = SimpleServer.new("localhost")
     @other_server = SimpleServer.new("127.0.0.1")

--- a/spec/gemstash/logging_spec.rb
+++ b/spec/gemstash/logging_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Gemstash::Logging do
+RSpec.describe Gemstash::Logging do
   it "builds a logger in the right place" do
     expect(File.exist?(TEST_LOG_FILE)).to be_truthy
   end
@@ -20,7 +20,7 @@ describe Gemstash::Logging do
   end
 end
 
-describe Gemstash::Logging::StreamLogger do
+RSpec.describe Gemstash::Logging::StreamLogger do
   let(:logger) { Gemstash::Logging::StreamLogger.new(Logger::INFO) }
   let(:error_logger) { Gemstash::Logging::StreamLogger.new(Logger::ERROR) }
 

--- a/spec/gemstash/rack_env_rewriter_spec.rb
+++ b/spec/gemstash/rack_env_rewriter_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "cgi"
 
-describe Gemstash::RackEnvRewriter do
+RSpec.describe Gemstash::RackEnvRewriter do
   context "with just a prefix to drop" do
     let(:env) do
       {

--- a/spec/gemstash/specs_builder_spec.rb
+++ b/spec/gemstash/specs_builder_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Gemstash::SpecsBuilder do
+RSpec.describe Gemstash::SpecsBuilder do
   let(:auth) { Gemstash::ApiKeyAuthorization.new(auth_key) }
   let(:auth_with_invalid_auth_key) { Gemstash::ApiKeyAuthorization.new(invalid_auth_key) }
   let(:auth_without_permission) { Gemstash::ApiKeyAuthorization.new(auth_key_without_permission) }

--- a/spec/gemstash/storage_spec.rb
+++ b/spec/gemstash/storage_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "yaml"
 
-describe Gemstash::Storage do
+RSpec.describe Gemstash::Storage do
   before do
     @folder = Dir.mktmpdir
   end

--- a/spec/gemstash/upstream_spec.rb
+++ b/spec/gemstash/upstream_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Gemstash::Upstream do
+RSpec.describe Gemstash::Upstream do
   it "parses an escaped uri" do
     upstream_uri = Gemstash::Upstream.new("https%3A%2F%2Frubygems.org%2F")
     expect(upstream_uri.to_s).to eq("https://rubygems.org/")
@@ -94,7 +94,7 @@ describe Gemstash::Upstream do
   end
 end
 
-describe Gemstash::Upstream::GemName do
+RSpec.describe Gemstash::Upstream::GemName do
   context "With a simple upstream" do
     let(:upstream) { Gemstash::Upstream.new("https://rubygems.org/") }
 

--- a/spec/gemstash/web_spec.rb
+++ b/spec/gemstash/web_spec.rb
@@ -5,7 +5,7 @@ require "faraday"
 require "fileutils"
 require "rack/test"
 
-describe Gemstash::Web do
+RSpec.describe Gemstash::Web do
   include Rack::Test::Methods
 
   let(:http_client_builder) do

--- a/spec/gemstash_spec.rb
+++ b/spec/gemstash_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Gemstash do
+RSpec.describe Gemstash do
   it "has a version number" do
     expect(Gemstash::VERSION).not_to be nil
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -6,7 +6,7 @@ require "json"
 require "net/http"
 require "uri"
 
-describe "gemstash integration tests" do
+RSpec.describe "gemstash integration tests" do
   let(:auth) { Gemstash::ApiKeyAuthorization.new(auth_key) }
   let(:auth_key) { "test-key" }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,8 @@ TEST_DB = Gemstash::Env.current.db
 Sequel::Model.db = TEST_DB
 
 RSpec.configure do |config|
+  config.disable_monkey_patching!
+
   config.around(:each) do |example|
     test_env.config = TEST_CONFIG unless test_env.config == TEST_CONFIG
 


### PR DESCRIPTION
This PR configures RSpec to avoid some now-unnecessary metaprogramming.

See http://rspec.info/documentation/3.8/rspec-core/RSpec/Core/Configuration.html#disable_monkey_patching!-instance_method

> Enables zero monkey patching mode for RSpec. It removes monkey patching of the top-level DSL methods (describe, shared_examples_for, etc) onto main and Module, instead requiring you to prefix these methods with RSpec.. It enables expect-only syntax for rspec-mocks and rspec-expectations. It simply disables monkey patching on whatever pieces of RSpec the user is using.



