### PR TITLE
Travis: update JRuby to 9.2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - language: generic
       env:
         - JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m"
-        - JRUBY_VERSION="jruby-9.2.0.0"
+        - JRUBY_VERSION="jruby-9.2.5.0"
       before_install:
         - ./ci/build/rvm_setup.sh
         - rm -f ${HOME}/.rvm/gemsets/jruby/global.gems


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.5.0.

[JRuby 9.2.5.0 release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)