### PR TITLE
gemspec: Allow Bundler 2.0, too

### DIFF
--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -51,7 +51,7 @@ you push your own private gems as well."
     spec.add_runtime_dependency "sqlite3", "~> 1.3"
   end
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", [">= 1.11", "< 3.0"]
   spec.add_development_dependency "citrus", "~> 3.0"
   spec.add_development_dependency "octokit", "~> 4.2"
   spec.add_development_dependency "pandoc_object_filters", "~> 0.2"

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -58,5 +58,5 @@ you push your own private gems as well."
   spec.add_development_dependency "rack-test", "~> 1.1"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "rubocop", "= 0.62.0"
+  spec.add_development_dependency "rubocop", "= 0.63.0"
 end


### PR DESCRIPTION
This PR is me trying to allow 2.0+ Bundler to be used, by changing the gemspec.