### PR TITLE
gemspec: Allow Bundler 2

### DIFF
--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -51,7 +51,7 @@ you push your own private gems as well."
     spec.add_runtime_dependency "sqlite3", "~> 1.3"
   end
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", [">= 1.11", "< 3.0"]
   spec.add_development_dependency "citrus", "~> 3.0"
   spec.add_development_dependency "octokit", "~> 4.2"
   spec.add_development_dependency "pandoc_object_filters", "~> 0.2"


### PR DESCRIPTION
This PR allows Bundler 2.0+ in the gemspec.

Reason: CI fails.

With this change, the CI's green again.