### PR TITLE
CI: Drop 2.3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
   include:
-    - rvm: 2.3.8
     - rvm: 2.4.6
     - rvm: 2.5.5
     - rvm: 2.6.2


### PR DESCRIPTION
This PR updates the CI matrix to **remove Ruby 2.3.8**.

EOL announcement blog post: https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/