### PR TITLE
Start work on backfilling for compact indexes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec
 gem "aruba"
 gem "citrus", "~> 3.0"
+gem "irb"
 gem "octokit"
 gem "rack-test", "~> 2.1"
 gem "rake", "~> 13.0"
@@ -32,3 +33,5 @@ group :test do
   gem "gem_server_conformance", "~> 0.1.5"
   gem "mock_redis"
 end
+
+gem "debug", "~> 1.11"

--- a/lib/gemstash.rb
+++ b/lib/gemstash.rb
@@ -4,6 +4,7 @@
 module Gemstash
   autoload :ApiKeyAuthorization, "gemstash/api_key_authorization"
   autoload :Authorization,       "gemstash/authorization"
+  autoload :Backfiller,          "gemstash/backfiller"
   autoload :DB,                  "gemstash/db"
   autoload :Cache,               "gemstash/cache"
   autoload :CLI,                 "gemstash/cli"

--- a/lib/gemstash/backfiller.rb
+++ b/lib/gemstash/backfiller.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 require "rubygems/package"
 
 module Gemstash
+  # Class that reviews existing data, and updates them to fix issues, prepare for new features, etc.
   class Backfiller
     include Gemstash::Env::Helper
 
@@ -49,6 +52,8 @@ module Gemstash
       @storage ||= Gemstash::Storage.for("private").for("gems")
     end
 
+    # Base class for running a specific backfill
+    #  Subclasses need to implement the `records` and `backfill` methods.
     class BackfillRunner
       def initialize(db, storage)
         @db = db
@@ -94,6 +99,7 @@ module Gemstash
       end
     end
 
+    # Backfill to support Compact Indexes
     class CompactIndexesBackfillRunner < BackfillRunner
       def records
         DB::Version.where(

--- a/lib/gemstash/backfiller.rb
+++ b/lib/gemstash/backfiller.rb
@@ -1,0 +1,86 @@
+require "rubygems/package"
+
+module Gemstash
+  class Backfiller
+    def initialize
+      @db = Gemstash::Env.current.db
+    end
+
+    def run
+      backfills.each do |backfill|
+        backfill.run
+      end
+    end
+
+
+    def backfills
+      @backfills ||= [
+        CompactIndexesBackfill.new(@db, storage)
+      ]
+    end
+
+    def needed?
+      backfills.any?(&:needed?)
+    end
+
+    def storage
+      @storage ||= Gemstash::Storage.for("private").for("gems")
+    end
+
+    class Backfill
+      def initialize(db, storage)
+        @db = db
+        @storage = storage
+      end
+
+      def needed?
+        records.count > 0
+      end
+
+      def records
+        raise NotImplementedError
+      end
+
+      def run
+        puts "Running backfill: #{self.class.name}"
+        puts "Records: #{records.count}"
+        records.each do |record|
+          puts "#{record.class.name}##{record.id}: #{record.full_name}"
+          backfill(record)
+        end
+      end
+
+      def backfill(record)
+        raise NotImplementedError
+      end
+    end
+
+    class CompactIndexesBackfill < Backfill
+      def records
+        DB::Version.where(
+          Sequel.or(
+            info_checksum: nil,
+            sha256: nil,
+          )
+        )
+      end
+
+      def backfill(record)
+        resource = @storage.resource(record.storage_id)
+        gem_contents = resource.content(:gem)  
+        gem = Gem::Package.new(StringIO.new(gem_contents))
+
+        sha256 = Digest::SHA256.base64digest(gem_contents)
+        spec = gem.spec
+
+        info = Gemstash::CompactIndexBuilder::Info.new(nil, record.rubygem.name).tap(&:build_result).result
+        record.update(
+          info_checksum: Digest::MD5.hexdigest(info),
+          sha256: sha256,
+          required_ruby_version: spec.required_ruby_version,
+          required_rubygems_version: spec.required_rubygems_version
+        )
+      end
+    end
+  end
+end

--- a/lib/gemstash/backfiller.rb
+++ b/lib/gemstash/backfiller.rb
@@ -27,7 +27,7 @@ module Gemstash
         affected_rows = backfill_runner.records.count
         backfill_runner.run
 
-        record.update(completed_at: Time.now, affected_rows: affected_rows)
+        backfill_runner.mark_completed(affected_rows: affected_rows)
       end
     end
 
@@ -92,6 +92,10 @@ module Gemstash
         end
 
         puts "Done!"
+      end
+
+      def mark_completed(affected_rows: 0)
+        backfill_record.update(completed_at: Time.now, affected_rows: affected_rows)
       end
 
       def backfill(record)

--- a/lib/gemstash/backfiller.rb
+++ b/lib/gemstash/backfiller.rb
@@ -2,10 +2,12 @@ require "rubygems/package"
 
 module Gemstash
   class Backfiller
-    attr_reader :db
+    include Gemstash::Env::Helpers
 
+    attr_reader :db
+    
     def initialize
-      @db = Gemstash::Env.current.db
+      @db = gemstash_env.db
     end
 
     def run

--- a/lib/gemstash/cli.rb
+++ b/lib/gemstash/cli.rb
@@ -14,6 +14,7 @@ module Gemstash
     autoload :Status,    "gemstash/cli/status"
     autoload :Stop,      "gemstash/cli/stop"
     autoload :Info,      "gemstash/cli/info"
+    autoload :Backfill,  "gemstash/cli/backfill"
 
     # Thor::Error for the CLI, which colors the message red.
     class Error < Thor::Error
@@ -107,6 +108,11 @@ module Gemstash
     desc "info", "Check current gemstash instance info"
     def info
       say Gemstash::CLI::Info.new(self).run
+    end
+
+    desc "backfill", "Check for any missing data from upgrades, and backfills the database"
+    def backfill
+      Gemstash::CLI::Backfill.new(self).run
     end
 
   private

--- a/lib/gemstash/cli.rb
+++ b/lib/gemstash/cli.rb
@@ -111,6 +111,10 @@ module Gemstash
     end
 
     desc "backfill", "Check for any missing data from upgrades, and backfills the database"
+    method_option :list, :type => :boolean, :default => false, :desc =>
+      "List all known backfills and their status"
+    method_option :rerun, :type => :string, :desc =>
+      "Re-run a specific backfill by name"
     def backfill
       Gemstash::CLI::Backfill.new(self).run
     end

--- a/lib/gemstash/cli/backfill.rb
+++ b/lib/gemstash/cli/backfill.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 require "terminal-table"
 
 module Gemstash
   class CLI
+    # This implements the command line backfill task:
+    #  $ gemstash backfill
     class Backfill < Gemstash::CLI::Base
       def run
         prepare
@@ -27,7 +31,7 @@ module Gemstash
         rows = backfills.map do |backfill|
           status = backfill.completed_at ? "Completed" : "Pending"
           completed_at = backfill.completed_at ? backfill.completed_at.strftime("%Y-%m-%d %H:%M:%S") : "N/A"
-          affected_rows = backfill.affected_rows || "N/A"
+          backfill.affected_rows || "N/A"
           [
             backfill.backfill_class,
             status,

--- a/lib/gemstash/cli/backfill.rb
+++ b/lib/gemstash/cli/backfill.rb
@@ -1,8 +1,65 @@
+require "terminal-table"
+
 module Gemstash
   class CLI
     class Backfill < Gemstash::CLI::Base
       def run
-        Gemstash::Backfiller.new.run
+        prepare
+
+        if @cli.options[:list]
+          list_backfills
+        elsif @cli.options[:rerun]
+          rerun_backfill
+        else
+          Gemstash::Backfiller.new.run
+        end
+      end
+
+    private
+
+      def list_backfills
+        backfills = Gemstash::DB::Backfill.all
+        if backfills.empty?
+          @cli.say "No backfills found in the database."
+          return
+        end
+
+        rows = backfills.map do |backfill|
+          status = backfill.completed_at ? "Completed" : "Pending"
+          completed_at = backfill.completed_at ? backfill.completed_at.strftime("%Y-%m-%d %H:%M:%S") : "N/A"
+          affected_rows = backfill.affected_rows || "N/A"
+          [
+            backfill.backfill_class,
+            status,
+            completed_at,
+            backfill.description
+          ]
+        end
+
+        @cli.say Terminal::Table.new(
+          headings: %w[Backfill Status Completed_At Description],
+          rows: rows,
+          style: { border_top: false, border_bottom: false, border_left: false, border_right: false }
+        )
+      end
+
+      def rerun_backfill
+        backfill_name = @cli.options[:rerun]
+        backfill_record = Gemstash::DB::Backfill.find(backfill_class: backfill_name)
+
+        unless backfill_record
+          available_backfills = Gemstash::DB::Backfill.all.map(&:backfill_class).join(", ")
+          raise Gemstash::CLI::Error.new(@cli, "Backfill '#{backfill_name}' not found.\nAvailable backfills: #{available_backfills}")
+        end
+
+        @cli.say "Re-running backfill: #{backfill_name}"
+
+        # Reset the backfill to pending status
+        backfill_record.update(completed_at: nil, affected_rows: nil)
+
+        # Run the specific backfill
+        backfiller = Gemstash::Backfiller.new
+        backfiller.run_specific_backfill(backfill_record)
       end
     end
   end

--- a/lib/gemstash/cli/backfill.rb
+++ b/lib/gemstash/cli/backfill.rb
@@ -1,0 +1,9 @@
+module Gemstash
+  class CLI
+    class Backfill < Gemstash::CLI::Base
+      def run
+        Gemstash::Backfiller.new.run
+      end
+    end
+  end
+end

--- a/lib/gemstash/cli/base.rb
+++ b/lib/gemstash/cli/base.rb
@@ -51,9 +51,9 @@ module Gemstash
         # For some installs (and new installs), the backfill may not even be needed if there's not affected rows.
         pending_backfills.reject! do |backfill|
           if backfill.needed?
-            backfill.mark_completed
             false
           else
+            backfill.mark_completed
             true
           end
         end

--- a/lib/gemstash/cli/base.rb
+++ b/lib/gemstash/cli/base.rb
@@ -46,6 +46,18 @@ module Gemstash
                                              "install version #{version} or later.")
       end
 
+      def check_backfills
+        # require 'debug'; debugger
+        pending_backfills = DB::Backfill.pending
+        if pending_backfills.any?
+          @cli.say(@cli.set_color("Backfills pending, some features may be disabled", :red))
+          pending_backfills.each do |backfill|
+            @cli.say(@cli.set_color("- #{backfill.backfill_class}: #{backfill.description}", :red))
+          end
+          @cli.say(@cli.set_color("Run `gemstash backfill` to fix this.", :red))
+        end
+      end
+
       def pidfile_args
         ["--pidfile", gemstash_env.pidfile]
       end

--- a/lib/gemstash/cli/start.rb
+++ b/lib/gemstash/cli/start.rb
@@ -11,6 +11,7 @@ module Gemstash
       def run
         prepare
         @cli.say("Starting gemstash!", :green)
+        check_backfills
         case @cli.options[:daemonize]
         when false then warn "The --no-daemonize option was removed and has no effect."
         when true then warn "The --daemonize option was removed and has no effect."

--- a/lib/gemstash/compact_index_builder.rb
+++ b/lib/gemstash/compact_index_builder.rb
@@ -14,9 +14,7 @@ module Gemstash
 
     def self.serve(app, ...)
       unless Gemstash::DB::Backfill.compact_index.completed?
-        app.status 404
-        app.body JSON.dump("error" => "Backfills pending, skipping compact index build", "code" => 404)
-        return
+        halt(404, { "Content-Type" => "text/plain; charset=utf-8" }, "Backfills pending, skipping compact index build")
       end
 
       app.content_type "text/plain; charset=utf-8"

--- a/lib/gemstash/compact_index_builder.rb
+++ b/lib/gemstash/compact_index_builder.rb
@@ -12,6 +12,12 @@ module Gemstash
     attr_reader :result
 
     def self.serve(app, ...)
+      unless Gemstash::DB::Backfill.compact_index.completed?
+        app.status 404
+        app.body JSON.dump("error" => "Backfills pending, skipping compact index build", "code" => 404)
+        return
+      end
+
       app.content_type "text/plain; charset=utf-8"
       body = new(app.auth, ...).serve
       app.etag Digest::MD5.hexdigest(body)

--- a/lib/gemstash/compact_index_builder.rb
+++ b/lib/gemstash/compact_index_builder.rb
@@ -7,6 +7,7 @@ require "stringio"
 require "zlib"
 
 module Gemstash
+  # Class that builds the compact index.
   class CompactIndexBuilder
     include Gemstash::Env::Helper
     attr_reader :result
@@ -72,6 +73,7 @@ module Gemstash
       @auth.check("fetch")
     end
 
+    # Builds the compact index for all versions.
     class Versions < CompactIndexBuilder
       def fetch_resource
         storage.resource("versions")
@@ -167,6 +169,7 @@ module Gemstash
       end
     end
 
+    # Builds the compact index for a specific gem.
     class Info < CompactIndexBuilder
       def initialize(auth, name)
         super(auth)
@@ -222,6 +225,7 @@ module Gemstash
       end
     end
 
+    # Builds the compact index for all names.
     class Names < CompactIndexBuilder
       def fetch_resource
         storage.resource("names")

--- a/lib/gemstash/compact_index_builder.rb
+++ b/lib/gemstash/compact_index_builder.rb
@@ -13,8 +13,6 @@ module Gemstash
     attr_reader :result
 
     def self.serve(app, ...)
-      halt(404, { "Content-Type" => "text/plain; charset=utf-8" }, "Backfills pending, skipping compact index build") unless Gemstash::DB::Backfill.compact_index.completed?
-
       app.content_type "text/plain; charset=utf-8"
       body = new(app.auth, ...).serve
       app.etag Digest::MD5.hexdigest(body)

--- a/lib/gemstash/compact_index_builder.rb
+++ b/lib/gemstash/compact_index_builder.rb
@@ -13,9 +13,7 @@ module Gemstash
     attr_reader :result
 
     def self.serve(app, ...)
-      unless Gemstash::DB::Backfill.compact_index.completed?
-        halt(404, { "Content-Type" => "text/plain; charset=utf-8" }, "Backfills pending, skipping compact index build")
-      end
+      halt(404, { "Content-Type" => "text/plain; charset=utf-8" }, "Backfills pending, skipping compact index build") unless Gemstash::DB::Backfill.compact_index.completed?
 
       app.content_type "text/plain; charset=utf-8"
       body = new(app.auth, ...).serve

--- a/lib/gemstash/db.rb
+++ b/lib/gemstash/db.rb
@@ -19,5 +19,6 @@ module Gemstash
     autoload :Rubygem,       "gemstash/db/rubygem"
     autoload :Upstream,      "gemstash/db/upstream"
     autoload :Version,       "gemstash/db/version"
+    autoload :Backfill,      "gemstash/db/backfill"
   end
 end

--- a/lib/gemstash/db/backfill.rb
+++ b/lib/gemstash/db/backfill.rb
@@ -1,0 +1,9 @@
+module Gemstash
+  module DB
+    class Backfill < Sequel::Model
+      def self.pending
+        where(completed_at: nil)
+      end
+    end
+  end
+end

--- a/lib/gemstash/db/backfill.rb
+++ b/lib/gemstash/db/backfill.rb
@@ -1,18 +1,20 @@
+# frozen_string_literal: true
+
 module Gemstash
   module DB
+    # Sequel model for backfills table.
     class Backfill < Sequel::Model
       def self.pending
         where(completed_at: nil)
       end
 
       def completed?
-       !!completed_at
+        !!completed_at
       end
 
       def self.compact_index
         where(backfill_class: "CompactIndexesBackfillRunner").first
       end
-
     end
   end
 end

--- a/lib/gemstash/db/backfill.rb
+++ b/lib/gemstash/db/backfill.rb
@@ -4,6 +4,15 @@ module Gemstash
       def self.pending
         where(completed_at: nil)
       end
+
+      def completed?
+       !!completed_at
+      end
+
+      def self.compact_index
+        where(backfill_class: "CompactIndexesBackfillRunner").first
+      end
+
     end
   end
 end

--- a/lib/gemstash/migrations/07_backfills.rb
+++ b/lib/gemstash/migrations/07_backfills.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Sequel.migration do
   change do
     create_table :backfills do

--- a/lib/gemstash/migrations/07_backfills.rb
+++ b/lib/gemstash/migrations/07_backfills.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  change do
+    create_table :backfills do
+      primary_key :id
+      String :backfill_class
+      Integer :affected_rows
+      String :gemstash_version_introduced
+      String :description
+      DateTime :completed_at
+    end
+  end
+end

--- a/lib/gemstash/migrations/08_compact_index_backfill.rb
+++ b/lib/gemstash/migrations/08_compact_index_backfill.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    from(:backfills).insert(
+      backfill_class: "CompactIndexesBackfillRunner",
+      gemstash_version_introduced: "2.9.0",
+      description: "Update existing versions to include information needed for compact indexes",
+      completed_at: nil,
+      affected_rows: nil
+    )
+  end
+
+  down do
+    from(:backfills).where(backfill_class: "CompactIndexesBackfillRunner").delete
+  end
+end

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -18,7 +18,7 @@ module Gemstash
       url = "https://#{url}" unless %r{^https?://}.match?(url)
       @uri = URI(url)
       @user_agent = user_agent
-      raise "URL '#{@uri}' is not valid!" unless @uri.to_s&.match?(URI::DEFAULT_PARSER.make_regexp)
+      raise "URL '#{@uri}' is not valid!" unless @uri.to_s.match?(URI::DEFAULT_PARSER.make_regexp)
     end
 
     def url(path = nil, params = nil)

--- a/spec/gemstash/cli/backfill_spec.rb
+++ b/spec/gemstash/cli/backfill_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Gemstash::CLI::Backfill do
     @said = ""
     result = double(options: cli_options)
     allow(result).to receive(:say) do |x|
-      @said += x.to_s + "\n"
+      @said += "#{x}\n"
       nil
     end
     allow(result).to receive(:set_color) {|x| x }

--- a/spec/gemstash/cli/backfill_spec.rb
+++ b/spec/gemstash/cli/backfill_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Gemstash::CLI::Backfill do
+  before do
+    # Don't let the environment change, else we get a separate test db
+    allow(Gemstash::Env).to receive(:current=).and_return(nil)
+  end
+
+  let(:cli) do
+    @said = ""
+    result = double(options: cli_options)
+    allow(result).to receive(:say) do |x|
+      @said += x.to_s + "\n"
+      nil
+    end
+    allow(result).to receive(:set_color) {|x| x }
+    result
+  end
+
+  let(:cli_options) { {} }
+
+  subject { described_class.new(cli) }
+
+  context "with no options" do
+    it "runs the normal backfill process" do
+      backfiller = double("backfiller")
+      expect(Gemstash::Backfiller).to receive(:new).and_return(backfiller)
+      expect(backfiller).to receive(:run)
+      subject.run
+    end
+  end
+
+  context "with --list option" do
+    let(:cli_options) { { list: true } }
+
+    it "lists all backfills" do
+      backfill_record = double(
+        backfill_class: "TestBackfill",
+        completed_at: Time.now,
+        affected_rows: 5,
+        description: "Test description"
+      )
+      allow(Gemstash::DB::Backfill).to receive(:all).and_return([backfill_record])
+      subject.run
+      expect(@said).to include("TestBackfill")
+      expect(@said).to include("Completed")
+      expect(@said).to include("Test description")
+    end
+
+    it "shows message when no backfills exist" do
+      allow(Gemstash::DB::Backfill).to receive(:all).and_return([])
+      subject.run
+      expect(@said).to include("No backfills found in the database.")
+    end
+  end
+
+  context "with --rerun option" do
+    let(:backfill_name) { "TestBackfill" }
+    let(:cli_options) { { rerun: backfill_name } }
+    let(:backfill_record) { double(backfill_class: backfill_name) }
+
+    it "reruns the specified backfill" do
+      allow(Gemstash::DB::Backfill).to receive(:find).with(backfill_class: backfill_name).and_return(backfill_record)
+      allow(backfill_record).to receive(:update)
+      backfiller = double("backfiller")
+      expect(Gemstash::Backfiller).to receive(:new).and_return(backfiller)
+      expect(backfiller).to receive(:run_specific_backfill).with(backfill_record)
+      subject.run
+      expect(@said).to include("Re-running backfill: #{backfill_name}")
+    end
+
+    it "resets the backfill to pending status" do
+      allow(Gemstash::DB::Backfill).to receive(:find).with(backfill_class: backfill_name).and_return(backfill_record)
+      expect(backfill_record).to receive(:update).with(completed_at: nil, affected_rows: nil)
+      backfiller = double("backfiller")
+      allow(Gemstash::Backfiller).to receive(:new).and_return(backfiller)
+      allow(backfiller).to receive(:run_specific_backfill)
+      subject.run
+    end
+
+    it "raises error for non-existent backfill" do
+      allow(Gemstash::DB::Backfill).to receive(:find).with(backfill_class: backfill_name).and_return(nil)
+      allow(Gemstash::DB::Backfill).to receive(:all).and_return([])
+      expect { subject.run }.to raise_error(Gemstash::CLI::Error, /Backfill 'TestBackfill' not found/)
+    end
+
+    it "shows available backfills in error message" do
+      existing_backfill = double(backfill_class: "ExistingBackfill")
+      allow(Gemstash::DB::Backfill).to receive(:find).with(backfill_class: backfill_name).and_return(nil)
+      allow(Gemstash::DB::Backfill).to receive(:all).and_return([existing_backfill])
+      expect { subject.run }.to raise_error(Gemstash::CLI::Error, /Available backfills: ExistingBackfill/)
+    end
+  end
+end


### PR DESCRIPTION
# Description:

Backfill logic for https://github.com/rubygems/gemstash/pull/392

# Tasks:

- [x] backfill class to handle backfilling compact indexes
- [x] CLI for backfilling
- [x] database table for tracking needed backfills and their status
- [x] update `gemstash start` (or more braodly) to check for pending backfills, and advise the user
- [x] add a check to tell if compact indexes are available (ie has run the backfill)
- [x] update PrivateSource to return 404 when compact indexes aren't available

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
