### PR TITLE
Make UpstreamSource intermediate info and versions from upstream

### DIFF
--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -128,6 +128,16 @@ module Gemstash
         serve_cached(id, :gem)
       end
 
+      def serve_info(name)
+        http_client = http_client_for(upstream)
+        http_client.get("info/#{name}")
+      end
+
+      def serve_versions
+        http_client = http_client_for(upstream)
+        http_client.get("versions")
+      end
+
       def serve_latest_specs
         http_client = http_client_for(upstream)
         http_client.get("latest_specs.4.8.gz")


### PR DESCRIPTION
This is similar to #337, adding two more endpoints that get intermediated by UpstreamSource instead of telling clients to talk directly to upstream rubygems, which breaks when clients use gemstash mirrors to avoid talking directly to rubygems.

# Description:

______________

# Tasks:

-  Describe the problem / feature
My clients running ruby 3.3 with new rubygems/bundler were failing to download gems due to these endpoints being missing
-  Write tests
I validated this on my mirror, same story as my testing in #337 

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
