### PR TITLE
Docs: fix typos in code comments

### DIFF
--- a/lib/gemstash/cli/setup.rb
+++ b/lib/gemstash/cli/setup.rb
@@ -84,7 +84,7 @@ module Gemstash
 
       def ask_memcached_details
         say_current_config(:memcached_servers, "Current Memcached servers")
-        servers = @cli.ask "What is the comma separated Memcached servers? [localhost:11211]"
+        servers = @cli.ask "What is the comma-separated Memcached servers? [localhost:11211]"
         servers = "localhost:11211" if servers.empty?
         @config[:memcached_servers] = servers
       end

--- a/lib/gemstash/env.rb
+++ b/lib/gemstash/env.rb
@@ -11,7 +11,7 @@ require "pathname"
 module Gemstash
   # Storage for application-wide variables and configuration.
   class Env
-    # The Gemstash::Env must be set before being retreived via
+    # The Gemstash::Env must be set before being retrieved via
     # Gemstash::Env.current. This error is thrown when that is not honored.
     class EnvNotSetError < StandardError
     end


### PR DESCRIPTION
## Summary

Fix two issues in code comments:

- `lib/gemstash/env.rb`: `retreived` → `retrieved`
- `lib/gemstash/cli/setup.rb`: `comma separated` → `comma-separated` (compound adjective)

No functional changes — comments and CLI prompt text only.